### PR TITLE
New landmark tracking website

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniship (0.3.1)
+    omniship (0.3.2)
       curb
       json
       nokogiri
@@ -23,10 +23,10 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     netrc (0.11.0)
-    nokogiri (1.7.0.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     rake (11.2.2)
     rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)

--- a/lib/omniship/landmark.rb
+++ b/lib/omniship/landmark.rb
@@ -5,7 +5,7 @@ module Omniship
   module Landmark
     LABEL = "Landmark"
     TRACKING_REGEX = /\b(LTN\d+N\d+)\b/i
-    TRACKING_URL = "https://mercury.landmarkglobal.com/tracking/track.php?trck="
+    TRACKING_URL = "https://track.landmarkglobal.com/?trck="
     TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S %Z"
     TIMEZONE = "CST"
 

--- a/lib/omniship/version.rb
+++ b/lib/omniship/version.rb
@@ -1,3 +1,3 @@
 module Omniship
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end


### PR DESCRIPTION
> Requests using either URL format will work for Mercury tracking until
June 30, 2018, at which time the old server will be deactivated.