### PR TITLE
"transferred to post office" != delivered

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniship (0.3.2)
+    omniship (0.3.3)
       curb
       json
       nokogiri
@@ -15,7 +15,7 @@ GEM
     curb (0.9.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.20161129)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -28,7 +28,7 @@ GEM
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     rake (11.2.2)
-    rest-client (2.0.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -52,7 +52,7 @@ GEM
     simplecov-html (0.10.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.5)
 
 PLATFORMS
   ruby

--- a/lib/omniship/ups/track/alternate_tracking.rb
+++ b/lib/omniship/ups/track/alternate_tracking.rb
@@ -7,14 +7,21 @@ module Omniship
         MANIFEST_ID = 'S'
         MMS_NUMBER = 'T'
         POSTAL_SERVICE_TRACKING_ID = 'Q'
-        
+
         def type
-          @root.xpath('Type').text
+          if @root.is_a? String # must be surepost
+            POSTAL_SERVICE_TRACKING_ID
+          else
+            @root.xpath('Type').text
+          end
         end
 
-
         def value
-          @root.xpath('Value').text
+          if @root.is_a? String
+            @root
+          else
+            @root.xpath('Value').text
+          end
         end
       end
     end

--- a/lib/omniship/ups/track/package.rb
+++ b/lib/omniship/ups/track/package.rb
@@ -19,11 +19,9 @@ module Omniship
           if !@root.xpath('PackageServiceOptions/USPSPICNumber').empty?
             # surepost
             path = @root.xpath('PackageServiceOptions/USPSPICNumber').text
-            puts "USPSPICNumber #{path}"
           else
             # mail innovations
             path = @root.xpath('AlternateTrackingInfo')
-            puts "non USPSPICNumber = #{path.to_xml.inspect}"
           end
 
           AlternateTracking.new(path) if !path.empty?

--- a/lib/omniship/ups/track/package.rb
+++ b/lib/omniship/ups/track/package.rb
@@ -16,8 +16,17 @@ module Omniship
         end
 
         def alternate_tracking
-          path = @root.xpath('AlternateTrackingInfo')
-          AlternateTracking.new(path) if path
+          if !@root.xpath('PackageServiceOptions/USPSPICNumber').empty?
+            # surepost
+            path = @root.xpath('PackageServiceOptions/USPSPICNumber').text
+            puts "USPSPICNumber #{path}"
+          else
+            # mail innovations
+            path = @root.xpath('AlternateTrackingInfo')
+            puts "non USPSPICNumber = #{path.to_xml.inspect}"
+          end
+
+          AlternateTracking.new(path) if !path.empty?
         end
 
         def has_left?
@@ -25,7 +34,7 @@ module Omniship
         end
 
         def has_arrived?
-          activity.any? {|activity| activity.code == ARRIVAL_CODE }
+          activity.any? {|activity| activity.code == ARRIVAL_CODE && !activity.status.include?("transferred to post office")}
         end
       end
     end

--- a/lib/omniship/version.rb
+++ b/lib/omniship/version.rb
@@ -1,3 +1,3 @@
 module Omniship
-  VERSION = '0.3.2'
+  VERSION = '0.3.3'
 end

--- a/spec/mock_responses.rb
+++ b/spec/mock_responses.rb
@@ -2,7 +2,7 @@ module MockResponses
   # here are some known API responses we can use to test our xml parsing
   def track_dhlgm_response
     "<track>
-      <shipment>        
+      <shipment>
         <trackingnumber>1071180100692707</trackingnumber>
         <deliveryconfirm>9261299996349762041684</deliveryconfirm>
         <customerconfirm>S725347170</customerconfirm>
@@ -144,7 +144,7 @@ module MockResponses
           <postalcode/>
           <country/>
         </event>
-        
+
       </shipment>
 
     </track>"
@@ -1353,6 +1353,347 @@ module MockResponses
           <ErrorDescription>Invalid tracking number</ErrorDescription>
         </Error>
       </Response>
+    </TrackResponse>"
+  end
+
+  def track_ups_surepost_response
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <TrackResponse>
+       <Response>
+          <TransactionReference>
+             <CustomerContext>320f2ecb-ff3e-4d5f-b93b-43becd9a046a</CustomerContext>
+             <XpciVersion>1.0</XpciVersion>
+          </TransactionReference>
+          <ResponseStatusCode>1</ResponseStatusCode>
+          <ResponseStatusDescription>Success</ResponseStatusDescription>
+       </Response>
+       <Shipment>
+          <Shipper>
+             <ShipperNumber>1161WA</ShipperNumber>
+             <Address>
+                <AddressLine1>S 507 2ND ST</AddressLine1>
+                <City>MILWAUKEE</City>
+                <StateProvinceCode>WI</StateProvinceCode>
+                <PostalCode>532041614</PostalCode>
+                <CountryCode>US</CountryCode>
+             </Address>
+          </Shipper>
+          <ShipTo>
+             <Address>
+                <City>LOS GATOS</City>
+                <StateProvinceCode>CA</StateProvinceCode>
+                <PostalCode>95032</PostalCode>
+                <CountryCode>US</CountryCode>
+             </Address>
+          </ShipTo>
+          <ShipmentWeight>
+             <UnitOfMeasurement>
+                <Code>LBS</Code>
+             </UnitOfMeasurement>
+             <Weight>4.80</Weight>
+          </ShipmentWeight>
+          <Service>
+             <Code>093</Code>
+             <Description>UPS SurePost</Description>
+          </Service>
+          <ReferenceNumber>
+             <Code>01</Code>
+             <Value>M681861103-1025</Value>
+          </ReferenceNumber>
+          <ShipmentIdentificationNumber>1Z1161WAYW93644228</ShipmentIdentificationNumber>
+          <PickupDate>20180522</PickupDate>
+          <Package>
+             <TrackingNumber>1Z1161WAYW93644228</TrackingNumber>
+             <DeliveryIndicator>N</DeliveryIndicator>
+             <RescheduledDeliveryDate>20180531</RescheduledDeliveryDate>
+             <PackageServiceOptions>
+                <USPSPICNumber>92612904851879541400755181</USPSPICNumber>
+             </PackageServiceOptions>
+             <Activity>
+                <ActivityLocation>
+                   <Address />
+                   <Description>Dock</Description>
+                </ActivityLocation>
+                <Status>
+                   <StatusType>
+                      <Code>I</Code>
+                      <Description>Received by the local post office</Description>
+                   </StatusType>
+                   <StatusCode>
+                      <Code>YH</Code>
+                   </StatusCode>
+                </Status>
+                <Date>20180530</Date>
+                <Time>034200</Time>
+             </Activity>
+             <Activity>
+                <ActivityLocation>
+                   <Address>
+                      <City>CAMPBELL</City>
+                      <PostalCode>95008</PostalCode>
+                      <CountryCode>US</CountryCode>
+                   </Address>
+                   <Code>AI</Code>
+                   <Description>Dock</Description>
+                   <SignedForByName>TO</SignedForByName>
+                </ActivityLocation>
+                <Status>
+                   <StatusType>
+                      <Code>D</Code>
+                      <Description>Package transferred to post office</Description>
+                   </StatusType>
+                   <StatusCode>
+                      <Code>LX</Code>
+                   </StatusCode>
+                </Status>
+                <Date>20180529</Date>
+                <Time>121524</Time>
+             </Activity>
+             <Activity>
+                <ActivityLocation>
+                   <Address>
+                      <City>San Jose</City>
+                      <StateProvinceCode>CA</StateProvinceCode>
+                      <CountryCode>US</CountryCode>
+                   </Address>
+                   <Description>Dock</Description>
+                </ActivityLocation>
+                <Status>
+                   <StatusType>
+                      <Code>I</Code>
+                      <Description>Destination Scan</Description>
+                   </StatusType>
+                   <StatusCode>
+                      <Code>YP</Code>
+                   </StatusCode>
+                </Status>
+                <Date>20180529</Date>
+                <Time>050247</Time>
+             </Activity>
+             <Activity>
+                <ActivityLocation>
+                   <Address>
+                      <City>San Jose</City>
+                      <StateProvinceCode>CA</StateProvinceCode>
+                      <CountryCode>US</CountryCode>
+                   </Address>
+                   <Description>Dock</Description>
+                </ActivityLocation>
+                <Status>
+                   <StatusType>
+                      <Code>I</Code>
+                      <Description>Destination Scan</Description>
+                   </StatusType>
+                   <StatusCode>
+                      <Code>DS</Code>
+                   </StatusCode>
+                </Status>
+                <Date>20180526</Date>
+                <Time>082028</Time>
+             </Activity>
+             <Activity>
+                <ActivityLocation>
+                   <Address>
+                      <City>San Jose</City>
+                      <StateProvinceCode>CA</StateProvinceCode>
+                      <CountryCode>US</CountryCode>
+                   </Address>
+                   <Description>Dock</Description>
+                </ActivityLocation>
+                <Status>
+                   <StatusType>
+                      <Code>X</Code>
+                      <Description>/ Package in transit and scheduled for UPS delivery attempt to recipient on next UPS business day.</Description>
+                   </StatusType>
+                   <StatusCode>
+                      <Code>6N</Code>
+                   </StatusCode>
+                </Status>
+                <Date>20180526</Date>
+                <Time>081930</Time>
+             </Activity>
+             <Activity>
+                <ActivityLocation>
+                   <Address>
+                      <City>San Jose</City>
+                      <StateProvinceCode>CA</StateProvinceCode>
+                      <CountryCode>US</CountryCode>
+                   </Address>
+                   <Description>Dock</Description>
+                </ActivityLocation>
+                <Status>
+                   <StatusType>
+                      <Code>I</Code>
+                      <Description>Arrival Scan</Description>
+                   </StatusType>
+                   <StatusCode>
+                      <Code>AR</Code>
+                   </StatusCode>
+                </Status>
+                <Date>20180526</Date>
+                <Time>055500</Time>
+             </Activity>
+             <Activity>
+                <ActivityLocation>
+                   <Address>
+                      <City>Oakland</City>
+                      <StateProvinceCode>CA</StateProvinceCode>
+                      <CountryCode>US</CountryCode>
+                   </Address>
+                   <Description>Dock</Description>
+                </ActivityLocation>
+                <Status>
+                   <StatusType>
+                      <Code>I</Code>
+                      <Description>Departure Scan</Description>
+                   </StatusType>
+                   <StatusCode>
+                      <Code>DP</Code>
+                   </StatusCode>
+                </Status>
+                <Date>20180526</Date>
+                <Time>050500</Time>
+             </Activity>
+             <Activity>
+                <ActivityLocation>
+                   <Address>
+                      <City>Oakland</City>
+                      <StateProvinceCode>CA</StateProvinceCode>
+                      <CountryCode>US</CountryCode>
+                   </Address>
+                   <Description>Dock</Description>
+                </ActivityLocation>
+                <Status>
+                   <StatusType>
+                      <Code>I</Code>
+                      <Description>Arrival Scan</Description>
+                   </StatusType>
+                   <StatusCode>
+                      <Code>AR</Code>
+                   </StatusCode>
+                </Status>
+                <Date>20180525</Date>
+                <Time>194300</Time>
+             </Activity>
+             <Activity>
+                <ActivityLocation>
+                   <Address>
+                      <City>San Pablo</City>
+                      <StateProvinceCode>CA</StateProvinceCode>
+                      <CountryCode>US</CountryCode>
+                   </Address>
+                   <Description>Dock</Description>
+                </ActivityLocation>
+                <Status>
+                   <StatusType>
+                      <Code>I</Code>
+                      <Description>Departure Scan</Description>
+                   </StatusType>
+                   <StatusCode>
+                      <Code>DP</Code>
+                   </StatusCode>
+                </Status>
+                <Date>20180525</Date>
+                <Time>190200</Time>
+             </Activity>
+             <Activity>
+                <ActivityLocation>
+                   <Address>
+                      <City>San Pablo</City>
+                      <StateProvinceCode>CA</StateProvinceCode>
+                      <CountryCode>US</CountryCode>
+                   </Address>
+                   <Description>Dock</Description>
+                </ActivityLocation>
+                <Status>
+                   <StatusType>
+                      <Code>I</Code>
+                      <Description>Arrival Scan</Description>
+                   </StatusType>
+                   <StatusCode>
+                      <Code>AR</Code>
+                   </StatusCode>
+                </Status>
+                <Date>20180525</Date>
+                <Time>163500</Time>
+             </Activity>
+             <Activity>
+                <ActivityLocation>
+                   <Address>
+                      <City>Oak Creek</City>
+                      <StateProvinceCode>WI</StateProvinceCode>
+                      <CountryCode>US</CountryCode>
+                   </Address>
+                   <Description>Dock</Description>
+                </ActivityLocation>
+                <Status>
+                   <StatusType>
+                      <Code>I</Code>
+                      <Description>Departure Scan</Description>
+                   </StatusType>
+                   <StatusCode>
+                      <Code>DP</Code>
+                   </StatusCode>
+                </Status>
+                <Date>20180523</Date>
+                <Time>074200</Time>
+             </Activity>
+             <Activity>
+                <ActivityLocation>
+                   <Address>
+                      <City>Oak Creek</City>
+                      <StateProvinceCode>WI</StateProvinceCode>
+                      <CountryCode>US</CountryCode>
+                   </Address>
+                   <Description>Dock</Description>
+                </ActivityLocation>
+                <Status>
+                   <StatusType>
+                      <Code>I</Code>
+                      <Description>Origin Scan</Description>
+                   </StatusType>
+                   <StatusCode>
+                      <Code>OR</Code>
+                   </StatusCode>
+                </Status>
+                <Date>20180522</Date>
+                <Time>220616</Time>
+             </Activity>
+             <Activity>
+                <ActivityLocation>
+                   <Address>
+                      <CountryCode>US</CountryCode>
+                   </Address>
+                   <Description>Dock</Description>
+                </ActivityLocation>
+                <Status>
+                   <StatusType>
+                      <Code>M</Code>
+                      <Description>Order Processed: Ready for UPS</Description>
+                   </StatusType>
+                   <StatusCode>
+                      <Code>MP</Code>
+                   </StatusCode>
+                </Status>
+                <Date>20180522</Date>
+                <Time>111527</Time>
+             </Activity>
+             <PackageWeight>
+                <UnitOfMeasurement>
+                   <Code>LBS</Code>
+                </UnitOfMeasurement>
+                <Weight>4.80</Weight>
+             </PackageWeight>
+             <ReferenceNumber>
+                <Code>01</Code>
+                <Value>M681861103-1025</Value>
+             </ReferenceNumber>
+             <Accessorial>
+                <Code>010</Code>
+                <Description>Hundredweight</Description>
+             </Accessorial>
+          </Package>
+       </Shipment>
     </TrackResponse>"
   end
 end

--- a/spec/ups/track_spec.rb
+++ b/spec/ups/track_spec.rb
@@ -2,28 +2,29 @@ require 'spec_helper'
 
 describe "UPS::Track" do
   # TODO - switch all these tests to webmock and we're good
-  it 'invalid tracking' do 
+  it 'invalid tracking' do
     skip "can't run on travis" if ENV["TRAVIS"]
     expect { Omniship::UPS.track(UPS_INVALID_TEST_NUMBER) }.to raise_error(Omniship::UPS::Track::Error)
   end
-  it 'arrived shipment' do 
+
+  it 'arrived shipment' do
     skip "can't run on travis" if ENV["TRAVIS"]
     trk = Omniship::UPS.track(UPS_VALID_TEST_NUMBER_DELIVERED)
     expect(trk.has_arrived?).to be true
   end
 
-  it 'left shipment' do 
+  it 'left shipment' do
     skip "can't run on travis" if ENV["TRAVIS"]
     trk = Omniship::UPS.track(UPS_VALID_TEST_NUMBER_ORIGIN_SCAN)
     expect(trk.has_arrived?).to be false
     expect(trk.has_left?).to be true
   end
 
-  it 'timstamp parsing' do 
+  it 'timstamp parsing' do
     expect(Omniship::UPS.parse_timestamp("20170117", "211600")).to eq(Time.parse("2017-01-17 21:16"))
   end
 
-  it 'test xml parsing' do 
+  it 'test xml parsing' do
     trk = Omniship::UPS::Track::Response.new(Nokogiri::XML::Document.parse(track_ups_response))
     expect(trk.has_left?).to eq true
     expect(trk.has_arrived?).to eq true
@@ -37,14 +38,36 @@ describe "UPS::Track" do
     expect(activity.timestamp).to_not be_nil
 
     alternate_tracking = package.alternate_tracking
+    expect(alternate_tracking).to be_nil
+  end
+
+  it 'text xml parsing of mail innovations' do
+    trk = Omniship::UPS::Track::Response.new(Nokogiri::XML::Document.parse(track_ups_mi_response))
+    expect(trk.has_left?).to eq true
+    expect(trk.has_arrived?).to eq false # will never get to true because this package doesn't know the result of the alternate_tracking package
+    package = trk.shipment.packages.first
+    expect(package.tracking_number).to_not be_nil
+
+    alternate_tracking = package.alternate_tracking
     expect(alternate_tracking).to_not be_nil
-    expect(alternate_tracking.type).to_not be_nil
+    expect(alternate_tracking.type).to eq(Omniship::UPS::Track::AlternateTracking::POSTAL_SERVICE_TRACKING_ID)
+    expect(alternate_tracking.value).to_not be_nil
+  end
+  it 'test xml parsing of surepost' do
+    trk = Omniship::UPS::Track::Response.new(Nokogiri::XML::Document.parse(track_ups_surepost_response))
+    expect(trk.has_left?).to eq true
+    expect(trk.has_arrived?).to eq false # will never get to true because this package doesn't know the result of the alternate_tracking package
+    package = trk.shipment.packages.first
+    expect(package.tracking_number).to_not be_nil
+
+    alternate_tracking = package.alternate_tracking
+    expect(alternate_tracking).to_not be_nil
+    expect(alternate_tracking.type).to eq(Omniship::UPS::Track::AlternateTracking::POSTAL_SERVICE_TRACKING_ID) # we fake this
     expect(alternate_tracking.value).to_not be_nil
   end
 
-  it 'test xml parsing not found' do 
+  it 'test xml parsing not found' do
     error = Omniship::UPS::Track::Error.new(Nokogiri::XML::Document.parse(track_ups_not_found_response))
     expect(error.code).to eq(Omniship::TrackError::NOT_FOUND)
   end
 end
-

--- a/spec/ups/track_spec.rb
+++ b/spec/ups/track_spec.rb
@@ -44,7 +44,7 @@ describe "UPS::Track" do
   it 'text xml parsing of mail innovations' do
     trk = Omniship::UPS::Track::Response.new(Nokogiri::XML::Document.parse(track_ups_mi_response))
     expect(trk.has_left?).to eq true
-    expect(trk.has_arrived?).to eq false # will never get to true because this package doesn't know the result of the alternate_tracking package
+    expect(trk.has_arrived?).to eq true
     package = trk.shipment.packages.first
     expect(package.tracking_number).to_not be_nil
 


### PR DESCRIPTION
When a UPS surepost order is handed off to USPS the code UPS uses is the same as the delivery code (D): 
<img width="683" alt="screen shot 2018-05-30 at 8 50 51 am" src="https://user-images.githubusercontent.com/1323524/40727470-91c885c6-63ed-11e8-879d-a08e652111bd.png">

I added in (essentially a hack) to not consider something delivered if the description says that it was given to USPS. Also fixed parsing the USPS tracking number for surepost packages and wrote parsing tests: 

![image](https://user-images.githubusercontent.com/1323524/40727336-4affb31c-63ed-11e8-8f6b-e00263f462d2.png)

I have an update to wantable-2 to track the USPS number of a surepost package as well 