### PR TITLE
Fallback to ANY package

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniship (0.3.3)
+    omniship (0.3.4)
       curb
       json
       nokogiri
@@ -12,21 +12,21 @@ GEM
   specs:
     codeclimate-test-reporter (1.0.5)
       simplecov
-    curb (0.9.3)
+    curb (0.9.10)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     json (2.0.3)
-    mime-types (3.1)
+    mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
-    mini_portile2 (2.3.0)
+    mime-types-data (3.2019.0331)
+    mini_portile2 (2.4.0)
     netrc (0.11.0)
-    nokogiri (1.8.2)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.3)
+      mini_portile2 (~> 2.4.0)
     rake (11.2.2)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
@@ -52,7 +52,7 @@ GEM
     simplecov-html (0.10.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.6)
 
 PLATFORMS
   ruby
@@ -65,4 +65,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.14.2
+   1.17.3

--- a/lib/omniship/newgistics/track/request.rb
+++ b/lib/omniship/newgistics/track/request.rb
@@ -3,12 +3,12 @@ module Omniship
     module Track
       class Request
         # https://apiint.newgistics.com/WebAPI/Shipment/help/operations/Tracking
-        
+
         TEST_URL = 'https://apiint.newgistics.com/WebAPI/Shipment/Tracking'
         LIVE_URL = 'https://api.newgistics.com/WebAPI/Shipment/Tracking'
 
         def self.endpoint
-          if Newgistics.test == true 
+          if Newgistics.test == true
             TEST_URL
           else
             LIVE_URL
@@ -19,12 +19,12 @@ module Omniship
           request = create_document(tracking_number, qualifier)
           response = get_response(request)
           parsed_response = JSON.parse(response)
-          package = parsed_response["Packages"].find{|p| p["TrackingNumber"] == tracking_number }
-          
+          package = parsed_response["Packages"].find{|p| p["TrackingNumber"] == tracking_number } || parsed_response["Packages"].first
+
           if error = package["ErrorMessage"] and error.length > 0
             raise Error.new(package)
           else
-            return Response.new(parsed_response) 
+            return Response.new(parsed_response)
           end
         end
 

--- a/lib/omniship/version.rb
+++ b/lib/omniship/version.rb
@@ -1,3 +1,3 @@
 module Omniship
-  VERSION = '0.3.3'
+  VERSION = '0.3.4'
 end


### PR DESCRIPTION
Sometimes Newgistics doesn't return a package with the same tracking number as what was requested.
EX:
![image](https://user-images.githubusercontent.com/1323524/57246063-fa696480-7001-11e9-9921-c4addf5e5628.png)
