### PR TITLE
Update FedEx Tracking Url

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniship (0.3.8)
+    omniship (0.3.9)
       curb
       json
       nokogiri
@@ -23,7 +23,7 @@ GEM
     mime-types-data (3.2021.0704)
     mini_portile2 (2.6.1)
     netrc (0.11.0)
-    nokogiri (1.12.0)
+    nokogiri (1.12.3)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     racc (1.5.2)

--- a/lib/omniship/fed_ex.rb
+++ b/lib/omniship/fed_ex.rb
@@ -6,7 +6,7 @@ module Omniship
     TRACKING_REGEX = [/(\b96\d{20}\b)|(\b\d{15}\b)|(\b\d{12}\b)/,
                       /\b((98\d\d\d\d\d?\d\d\d\d|98\d\d) ?\d\d\d\d ?\d\d\d\d( ?\d\d\d)?)\b/,
                       /^[0-9]{15}$/]
-    TRACKING_URL = "http://www.fedex.com/Tracking?action=track&tracknumbers="
+    TRACKING_URL = "https://www.fedex.com/fedextrack/?tracknumbers="
 
     def self.tracking_test?(tracking)
       TRACKING_REGEX.any?{|regex| tracking =~ regex}

--- a/lib/omniship/version.rb
+++ b/lib/omniship/version.rb
@@ -1,3 +1,3 @@
 module Omniship
-  VERSION = '0.3.8'
+  VERSION = '0.3.9'
 end


### PR DESCRIPTION
Use the same url that google uses when you search for the tracking number.