### PR TITLE
UPS API updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniship (0.3.13)
+    omniship (0.3.14)
       curb
       json
       nokogiri (= 1.16)
@@ -12,21 +12,20 @@ GEM
   specs:
     curb (1.0.5)
     diff-lcs (1.2.5)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
+    domain_name (0.6.20240107)
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
-    json (2.6.3)
-    mime-types (3.5.1)
+    json (2.7.2)
+    mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2023.0808)
-    mini_portile2 (2.8.4)
+    mime-types-data (3.2024.0507)
+    mini_portile2 (2.8.6)
     netrc (0.11.0)
     nokogiri (1.16.0)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    racc (1.7.1)
+    racc (1.8.0)
     rake (11.2.2)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -46,9 +45,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.8.2)
 
 PLATFORMS
   ruby

--- a/lib/omniship.rb
+++ b/lib/omniship.rb
@@ -71,7 +71,10 @@ module Omniship
         UPS.username = ups['username']
         UPS.password = ups['password']
         UPS.token = ups['token']
+        UPS.client_id = ups['client_id']
+        UPS.client_secret = ups['client_secret']
         UPS.test = ups['test']
+        UPS.source = ups['source']
       end
 
       if landmark = omniship['Landmark']

--- a/lib/omniship/ups.rb
+++ b/lib/omniship/ups.rb
@@ -12,6 +12,9 @@ module Omniship
       attr_accessor :username
       attr_accessor :password
       attr_accessor :token
+      attr_accessor :client_id
+      attr_accessor :client_secret
+      attr_accessor :source
       attr_accessor :test
     end
 

--- a/lib/omniship/ups/track/activity.rb
+++ b/lib/omniship/ups/track/activity.rb
@@ -11,7 +11,7 @@ module Omniship
         end
 
         def code
-          @root.dig('status', 'statusCode').to_s
+          @root.dig('status', 'type')
         end
 
         def timestamp

--- a/lib/omniship/ups/track/activity.rb
+++ b/lib/omniship/ups/track/activity.rb
@@ -2,23 +2,20 @@ module Omniship
   module UPS
     module Track
       class Activity < Omniship::Base
-
         def address
-          Address.new(@root.xpath('ActivityLocation').xpath('Address'))
+          Address.new(@root.dig('location', 'address'))
         end
 
         def status
-          @root.xpath('Status/StatusType/Description').text
+          @root.dig('status', 'description')
         end
 
-        def code 
-          @root.xpath('Status/StatusType/Code').text
+        def code
+          @root.dig('status', 'code').to_s
         end
 
         def timestamp
-          date = @root.xpath('Date/text()').to_s
-          time = @root.xpath('Time/text()').to_s
-          Omniship::UPS.parse_timestamp(date, time)
+          Omniship::UPS.parse_timestamp(@root['date'], @root['time'])
         end
       end
     end

--- a/lib/omniship/ups/track/activity.rb
+++ b/lib/omniship/ups/track/activity.rb
@@ -11,7 +11,7 @@ module Omniship
         end
 
         def code
-          @root.dig('status', 'code').to_s
+          @root.dig('status', 'statusCode').to_s
         end
 
         def timestamp

--- a/lib/omniship/ups/track/address.rb
+++ b/lib/omniship/ups/track/address.rb
@@ -2,21 +2,20 @@ module Omniship
   module UPS
     module Track
       class Address < Omniship::Base
-
         def city
-          @root.xpath('City/text()').to_s
+          @root['city']
         end
 
         def state
-          @root.xpath('StateProvinceCode/text()').to_s
+          @root['stateProvince']
         end
 
         def country
-          @root.xpath('CountryCode/text()').to_s
+          @root['country']
         end
 
         def postal_code
-          @root.xpath('PostalCode/text()').to_s
+          @root['postalCode']
         end
 
         def to_s

--- a/lib/omniship/ups/track/alternate_tracking.rb
+++ b/lib/omniship/ups/track/alternate_tracking.rb
@@ -12,7 +12,7 @@ module Omniship
         end
 
         def value
-          @root['value']
+          @root['number']
         end
       end
     end

--- a/lib/omniship/ups/track/alternate_tracking.rb
+++ b/lib/omniship/ups/track/alternate_tracking.rb
@@ -2,26 +2,17 @@ module Omniship
   module UPS
     module Track
       class AlternateTracking < Omniship::Base
-
         PACKAGE_ID = 'P'
         MANIFEST_ID = 'S'
         MMS_NUMBER = 'T'
         POSTAL_SERVICE_TRACKING_ID = 'Q'
 
         def type
-          if @root.is_a? String # must be surepost
-            POSTAL_SERVICE_TRACKING_ID
-          else
-            @root.xpath('Type').text
-          end
+          @root['type']
         end
 
         def value
-          if @root.is_a? String
-            @root
-          else
-            @root.xpath('Value').text
-          end
+          @root['value']
         end
       end
     end

--- a/lib/omniship/ups/track/error.rb
+++ b/lib/omniship/ups/track/error.rb
@@ -2,13 +2,11 @@ module Omniship
   module UPS
     module Track
       class Error < TrackError
-        NOT_FOUND_RESPONSES = ["Invalid tracking number", "Tracking Information not found"]
-        def initialize(root)
-          message = root.xpath("TrackResponse/Response/Error/ErrorDescription/text()").to_s
-          if NOT_FOUND_RESPONSES.any?{|r| message.include?(r) }
-            self.code = NOT_FOUND
-          end
-          super(message)
+        # errors are an array of { code: 'string', message: 'string' }
+        def initialize(code, errors)
+          self.code = NOT_FOUND if code == 404
+
+          super(errors.map { |e| e['message'] }.join(', '))
         end
       end
     end

--- a/lib/omniship/ups/track/package.rb
+++ b/lib/omniship/ups/track/package.rb
@@ -3,10 +3,8 @@ module Omniship
     module Track
       class Package < Omniship::Base
         # https://developer.ups.com/api/reference/tracking/api-code?loc=en_US
-
-        IN_TRANSIT_CODE = '005'
-        CLEARED_CUSTOMS = '014'
-        DELIVERED_CODE = '011'
+        DEPARTURE_CODE = "I"
+        ARRIVAL_CODE = "D"
 
         def tracking_number
           @root['trackingNumber']
@@ -29,11 +27,11 @@ module Omniship
         end
 
         def has_left?
-          activity.any? { |activity| activity.code == IN_TRANSIT_CODE || activity.code == CLEARED_CUSTOMS }
+          activity.any? { |activity| activity.code == DEPARTURE_CODE }
         end
 
         def has_arrived?
-          activity.any? { |activity| activity.code == DELIVERED_CODE && !activity.status.include?("transferred to post office")}
+          activity.any? { |activity| activity.code == ARRIVAL_CODE && !activity.status.include?("transferred to post office")}
         end
       end
     end

--- a/lib/omniship/ups/track/package.rb
+++ b/lib/omniship/ups/track/package.rb
@@ -21,7 +21,8 @@ module Omniship
         end
 
         def alternate_tracking
-          numbers = @root['AlternateTrackingNumber'] || []
+          puts "@root['alternateTrackingNumber']: #{@root['alternateTrackingNumber']}"
+          numbers = @root['alternateTrackingNumber'] || []
 
           AlternateTracking.new(numbers.first) unless numbers.empty?
         end

--- a/lib/omniship/ups/track/package.rb
+++ b/lib/omniship/ups/track/package.rb
@@ -21,7 +21,7 @@ module Omniship
         end
 
         def alternate_tracking
-          numbers = @root['AlternateTrackingNumber']
+          numbers = @root['AlternateTrackingNumber'] || []
 
           AlternateTracking.new(numbers.first) unless numbers.empty?
         end

--- a/lib/omniship/ups/track/package.rb
+++ b/lib/omniship/ups/track/package.rb
@@ -21,7 +21,6 @@ module Omniship
         end
 
         def alternate_tracking
-          puts "@root['alternateTrackingNumber']: #{@root['alternateTrackingNumber']}"
           numbers = @root['alternateTrackingNumber'] || []
 
           AlternateTracking.new(numbers.first) unless numbers.empty?

--- a/lib/omniship/ups/track/package.rb
+++ b/lib/omniship/ups/track/package.rb
@@ -6,33 +6,31 @@ module Omniship
         ARRIVAL_CODE = "D"
 
         def tracking_number
-          @root.xpath('TrackingNumber/text()').to_s
+          @root['trackingNumber']
+        end
+
+        def delivery_dates
+          @root['deliveryDate'].map { |dd| dd['date'] }
         end
 
         def activity
-          @root.xpath('Activity').map do |act|
+          @root['activity'].map do |act|
             Activity.new(act)
           end
         end
 
         def alternate_tracking
-          if !@root.xpath('PackageServiceOptions/USPSPICNumber').empty?
-            # surepost
-            path = @root.xpath('PackageServiceOptions/USPSPICNumber').text
-          else
-            # mail innovations
-            path = @root.xpath('AlternateTrackingInfo')
-          end
+          numbers = @root['AlternateTrackingNumber']
 
-          AlternateTracking.new(path) if !path.empty?
+          AlternateTracking.new(numbers.first) unless numbers.empty?
         end
 
         def has_left?
-          activity.any? {|activity| activity.code == DEPARTURE_CODE }
+          activity.any? { |activity| activity.code == DEPARTURE_CODE }
         end
 
         def has_arrived?
-          activity.any? {|activity| activity.code == ARRIVAL_CODE && !activity.status.include?("transferred to post office")}
+          activity.any? { |activity| activity.code == ARRIVAL_CODE && !activity.status.include?("transferred to post office")}
         end
       end
     end

--- a/lib/omniship/ups/track/package.rb
+++ b/lib/omniship/ups/track/package.rb
@@ -2,8 +2,11 @@ module Omniship
   module UPS
     module Track
       class Package < Omniship::Base
-        DEPARTURE_CODE = "I"
-        ARRIVAL_CODE = "D"
+        # https://developer.ups.com/api/reference/tracking/api-code?loc=en_US
+
+        IN_TRANSIT_CODE = '005'
+        CLEARED_CUSTOMS = '014'
+        DELIVERED_CODE = '011'
 
         def tracking_number
           @root['trackingNumber']
@@ -26,11 +29,11 @@ module Omniship
         end
 
         def has_left?
-          activity.any? { |activity| activity.code == DEPARTURE_CODE }
+          activity.any? { |activity| activity.code == IN_TRANSIT_CODE || activity.code == CLEARED_CUSTOMS }
         end
 
         def has_arrived?
-          activity.any? { |activity| activity.code == ARRIVAL_CODE && !activity.status.include?("transferred to post office")}
+          activity.any? { |activity| activity.code == DELIVERED_CODE && !activity.status.include?("transferred to post office")}
         end
       end
     end

--- a/lib/omniship/ups/track/request.rb
+++ b/lib/omniship/ups/track/request.rb
@@ -33,6 +33,11 @@ module Omniship
             raise Error.new(raw_response.code, response.dig('response', 'errors'))
           end
 
+          # Sometimes the tracking number is technically valid but doesn't actually exist. Still want to raise not found
+          if raw_response.code == 200 && response.dig('trackResponse', 'shipment')&.first&.key?('warnings')
+            raise Error.new(404, response.dig('trackResponse', 'shipment').first['warnings'])
+          end
+
           Response.new(response)
         end
 

--- a/lib/omniship/ups/track/request.rb
+++ b/lib/omniship/ups/track/request.rb
@@ -29,7 +29,7 @@ module Omniship
             puts response.inspect
           end
 
-          if response['response'].key?('errors')
+          unless response.dig('response', 'errors').nil?
             raise Error.new(raw_response.code, response.dig('response', 'errors'))
           end
 

--- a/lib/omniship/ups/track/request.rb
+++ b/lib/omniship/ups/track/request.rb
@@ -24,9 +24,15 @@ module Omniship
 
           response = JSON.parse(raw_response.body)
 
-          unless response.dig('response', 'errors').nil?
+          puts raw_response.code if Omniship.debug
+
+          if response['response'].key?('errors')
             raise Error.new(raw_response.code, response.dig('response', 'errors'))
+          elsif response['response'].key?('warnings')
+            raise Error.new(raw_response.code, response.dig('response', 'warnings'))
           end
+
+
 
           Response.new(response)
         end

--- a/lib/omniship/ups/track/request.rb
+++ b/lib/omniship/ups/track/request.rb
@@ -39,7 +39,7 @@ module Omniship
         private
 
         def self.oauth_client_credentials
-          if @oauth_client_credentials && oauth_client_credentials[:expires_at] > Time.zone.now.to_i
+          if @oauth_client_credentials && @oauth_client_credentials[:expires_at] > Time.zone.now.to_i
             return @oauth_client_credentials[:access_token]
           end
 

--- a/lib/omniship/ups/track/request.rb
+++ b/lib/omniship/ups/track/request.rb
@@ -31,8 +31,6 @@ module Omniship
 
           if response['response'].key?('errors')
             raise Error.new(raw_response.code, response.dig('response', 'errors'))
-          elsif response['response'].key?('warnings')
-            raise Error.new(raw_response.code, response.dig('response', 'warnings'))
           end
 
           Response.new(response)

--- a/lib/omniship/ups/track/request.rb
+++ b/lib/omniship/ups/track/request.rb
@@ -24,15 +24,16 @@ module Omniship
 
           response = JSON.parse(raw_response.body)
 
-          puts raw_response.code if Omniship.debug
+          if Omniship.debug
+            puts raw_response.code
+            puts response.inspect
+          end
 
           if response['response'].key?('errors')
             raise Error.new(raw_response.code, response.dig('response', 'errors'))
           elsif response['response'].key?('warnings')
             raise Error.new(raw_response.code, response.dig('response', 'warnings'))
           end
-
-
 
           Response.new(response)
         end

--- a/lib/omniship/ups/track/response.rb
+++ b/lib/omniship/ups/track/response.rb
@@ -4,7 +4,7 @@ module Omniship
       class Response < Omniship::Base
 
         def shipment
-          @shipment ||= Track::Shipment.new(@root.dig('trackResponse', 'shipment'))
+          @shipment ||= Track::Shipment.new(@root.dig('trackResponse', 'shipment')&.first)
         end
 
         def has_left?

--- a/lib/omniship/ups/track/response.rb
+++ b/lib/omniship/ups/track/response.rb
@@ -4,15 +4,15 @@ module Omniship
       class Response < Omniship::Base
 
         def shipment
-          Track::Shipment.new(@root.xpath("TrackResponse/Shipment"))
+          @shipment ||= Track::Shipment.new(@root.dig('trackResponse', 'shipment'))
         end
 
         def has_left?
-          !shipment.packages.empty? and shipment.packages.all?(&:has_left?)
+          !shipment.packages.empty? && shipment.packages.all?(&:has_left?)
         end
 
         def has_arrived?
-          !shipment.packages.empty? and shipment.packages.all?(&:has_arrived?)
+          !shipment.packages.empty? && shipment.packages.all?(&:has_arrived?)
         end
       end
     end

--- a/lib/omniship/ups/track/shipment.rb
+++ b/lib/omniship/ups/track/shipment.rb
@@ -2,6 +2,12 @@ module Omniship
   module UPS
     module Track
       class Shipment < Omniship::Base
+        def initialize(root)
+          super(root)
+
+          raise Error.new(404, @root['warnings']) if @root.key?('warnings')
+        end
+
         def packages
           @packages ||= @root['package'].map do |package|
             Package.new(package)

--- a/lib/omniship/ups/track/shipment.rb
+++ b/lib/omniship/ups/track/shipment.rb
@@ -3,6 +3,8 @@ module Omniship
     module Track
       class Shipment < Omniship::Base
         def packages
+          return [] unless @root.key?('package')
+
           @packages ||= @root['package'].map do |package|
             Package.new(package)
           end

--- a/lib/omniship/ups/track/shipment.rb
+++ b/lib/omniship/ups/track/shipment.rb
@@ -2,12 +2,6 @@ module Omniship
   module UPS
     module Track
       class Shipment < Omniship::Base
-        def initialize(root)
-          super(root)
-
-          raise Error.new(404, @root['warnings']) if @root.key?('warnings')
-        end
-
         def packages
           @packages ||= @root['package'].map do |package|
             Package.new(package)

--- a/lib/omniship/ups/track/shipment.rb
+++ b/lib/omniship/ups/track/shipment.rb
@@ -2,16 +2,15 @@ module Omniship
   module UPS
     module Track
       class Shipment < Omniship::Base
-
         def packages
-          @root.xpath('Package').map do |package|
+          @packages ||= @root['package'].map do |package|
             Package.new(package)
           end
         end
 
         def scheduled_delivery
-          date = @root.xpath('Package/RescheduledDeliveryDate').text
-          date = @root.xpath('ScheduledDeliveryDate').text if date.nil? || date.empty?
+          date = packages.flat_map(&:delivery_dates).first
+
           Omniship::UPS.parse_timestamp(date) if date && !date.empty?
         end
       end

--- a/lib/omniship/version.rb
+++ b/lib/omniship/version.rb
@@ -1,3 +1,3 @@
 module Omniship
-  VERSION = '0.3.13'
+  VERSION = '0.3.14'
 end

--- a/spec/mock_responses.rb
+++ b/spec/mock_responses.rb
@@ -1338,22 +1338,14 @@ module MockResponses
   end
 
   def track_ups_not_found_response
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-    <TrackResponse>
-      <Response>
-        <TransactionReference>
-          <CustomerContext>52c13489-7a9f-4cb1-b0b8-951274a4fc6c</CustomerContext>
-          <XpciVersion>1.0</XpciVersion>
-        </TransactionReference>
-        <ResponseStatusCode>0</ResponseStatusCode>
-        <ResponseStatusDescription>Failure</ResponseStatusDescription>
-        <Error>
-          <ErrorSeverity>Hard</ErrorSeverity>
-          <ErrorCode>150022</ErrorCode>
-          <ErrorDescription>Invalid tracking number</ErrorDescription>
-        </Error>
-      </Response>
-    </TrackResponse>"
+    {
+      "trackResponse" => {
+        "shipment" => [{
+          "inquiryNumber" => "1Z9912350341235622",
+          "warnings" => [{"code" => "TW0001", "message" => "Tracking Information Not Found"}]
+        }]
+      }
+    }
   end
 
   def track_ups_surepost_response

--- a/spec/mock_responses.rb
+++ b/spec/mock_responses.rb
@@ -620,352 +620,376 @@ module MockResponses
   end
 
   def track_ups_response
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-    <TrackResponse>
-      <Response>
-        <TransactionReference>
-          <CustomerContext>9cbf1901-c9d8-419e-b52c-e224ad693781</CustomerContext>
-          <XpciVersion>1.0</XpciVersion>
-        </TransactionReference>
-        <ResponseStatusCode>1</ResponseStatusCode>
-        <ResponseStatusDescription>Success</ResponseStatusDescription>
-      </Response>
-      <Shipment>
-        <Shipper>
-          <ShipperNumber>1161WA</ShipperNumber>
-          <Address>
-            <AddressLine1>112 E MINERAL ST</AddressLine1>
-            <City>MILWAUKEE</City>
-            <StateProvinceCode>WI</StateProvinceCode>
-            <PostalCode>53204  1876</PostalCode>
-            <CountryCode>US</CountryCode>
-          </Address>
-        </Shipper>
-        <ShipTo>
-          <Address>
-            <City>SANTA CLARA</City>
-            <StateProvinceCode>CA</StateProvinceCode>
-            <PostalCode>95053</PostalCode>
-            <CountryCode>US</CountryCode>
-          </Address>
-        </ShipTo>
-        <ShipmentWeight>
-          <UnitOfMeasurement>
-            <Code>LBS</Code>
-          </UnitOfMeasurement>
-          <Weight>3.90</Weight>
-        </ShipmentWeight>
-        <Service>
-          <Code>003</Code>
-          <Description>UPS GROUND</Description>
-        </Service>
-        <ReferenceNumber>
-          <Code>01</Code>
-          <Value>W886314636-875</Value>
-        </ReferenceNumber>
-        <ShipmentIdentificationNumber>1Z1161WA0394673667</ShipmentIdentificationNumber>
-        <PickupDate>20170110</PickupDate>
-        <DeliveryDateUnavailable>
-          <Type>Scheduled Delivery</Type>
-          <Description>Scheduled Delivery Date is not currently available, please try back later</Description>
-        </DeliveryDateUnavailable>
-        <Package>
-          <TrackingNumber>1Z1161WA0394673667</TrackingNumber>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>SANTA CLARA</City>
-                <StateProvinceCode>CA</StateProvinceCode>
-                <PostalCode>95053</PostalCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-              <Code>AI</Code>
-              <Description>DOCK</Description>
-              <SignedForByName>DANIGNACIO</SignedForByName>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>D</Code>
-                <Description>DELIVERED</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>KB</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170117</Date>
-            <Time>101600</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>SUNNYVALE</City>
-                <StateProvinceCode>CA</StateProvinceCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>OUT FOR DELIVERY</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>DS</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170117</Date>
-            <Time>055500</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>SUNNYVALE</City>
-                <StateProvinceCode>CA</StateProvinceCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>X</Code>
-                <Description>DELIVERY HAS BEEN RESCHEDULED DUE TO HOLIDAY CLOSURES. / YOUR DELIVERY HAS BEEN RESCHEDULED FOR THE NEXT BUSINESS DAY.</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>AZ</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170116</Date>
-            <Time>100000</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>SUNNYVALE</City>
-                <StateProvinceCode>CA</StateProvinceCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>DESTINATION SCAN</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>DS</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170116</Date>
-            <Time>044900</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>SUNNYVALE</City>
-                <StateProvinceCode>CA</StateProvinceCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>ARRIVAL SCAN</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>AR</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170114</Date>
-            <Time>060500</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>SOUTH SAN FRANCISCO</City>
-                <StateProvinceCode>CA</StateProvinceCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>DEPARTURE SCAN</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>DP</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170114</Date>
-            <Time>043900</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>SOUTH SAN FRANCISCO</City>
-                <StateProvinceCode>CA</StateProvinceCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>ARRIVAL SCAN</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>AR</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170113</Date>
-            <Time>211000</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>SAN PABLO</City>
-                <StateProvinceCode>CA</StateProvinceCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>DEPARTURE SCAN</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>DP</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170113</Date>
-            <Time>201500</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>SAN PABLO</City>
-                <StateProvinceCode>CA</StateProvinceCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>ARRIVAL SCAN</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>AR</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170113</Date>
-            <Time>143400</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>HODGKINS</City>
-                <StateProvinceCode>IL</StateProvinceCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>DEPARTURE SCAN</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>DP</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170111</Date>
-            <Time>090100</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>HODGKINS</City>
-                <StateProvinceCode>IL</StateProvinceCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>ARRIVAL SCAN</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>AR</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170111</Date>
-            <Time>070600</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>OAK CREEK</City>
-                <StateProvinceCode>WI</StateProvinceCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>DEPARTURE SCAN</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>DP</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170111</Date>
-            <Time>051800</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>OAK CREEK</City>
-                <StateProvinceCode>WI</StateProvinceCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>ORIGIN SCAN</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>OR</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170110</Date>
-            <Time>201200</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <CountryCode>US</CountryCode>
-              </Address>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>M</Code>
-                <Description>BILLING INFORMATION RECEIVED</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>MP</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170110</Date>
-            <Time>123448</Time>
-          </Activity>
-          <PackageWeight>
-            <UnitOfMeasurement>
-              <Code>LBS</Code>
-            </UnitOfMeasurement>
-            <Weight>3.90</Weight>
-          </PackageWeight>
-          <ReferenceNumber>
-            <Code>01</Code>
-            <Value>W886314636-875</Value>
-          </ReferenceNumber>
-        </Package>
-      </Shipment>
-    </TrackResponse>"
+    {
+      "trackResponse": {
+        "shipment": [
+          {
+            "inquiryNumber": "1Z1202R66698804005",
+            "package": [
+              {
+                "trackingNumber": "1Z1202R66698804005",
+                "deliveryDate": [],
+                "activity": [
+                  {
+                    "location": {
+                      "slic": "9642"
+                    },
+                    "status": {
+                      "type": "X",
+                      "description": "The package is at the clearing agency awaiting final release.",
+                      "statusCode": "092"
+                    },
+                    "date": "20240320",
+                    "time": "190838",
+                    "gmtDate": "20240320",
+                    "gmtOffset": "+08:00",
+                    "gmtTime": "11:08:38"
+                  },
+                  {
+                    "location": {
+                      "address": {
+                        "city": "Changi",
+                        "countryCode": "SG",
+                        "country": "SG"
+                      },
+                      "slic": "0009"
+                    },
+                    "status": {
+                      "type": "I",
+                      "description": "Arrived at Facility",
+                      "code": "AR",
+                      "statusCode": "005"
+                    },
+                    "date": "20240320",
+                    "time": "070700",
+                    "gmtDate": "20240319",
+                    "gmtOffset": "+08:00",
+                    "gmtTime": "23:07:00"
+                  },
+                  {
+                    "location": {
+                      "address": {
+                        "city": "Shenzhen",
+                        "countryCode": "CN",
+                        "country": "CN"
+                      },
+                      "slic": "0009"
+                    },
+                    "status": {
+                      "type": "I",
+                      "description": "Departed from Facility",
+                      "code": "DP",
+                      "statusCode": "005"
+                    },
+                    "date": "20240320",
+                    "time": "032000",
+                    "gmtDate": "20240319",
+                    "gmtOffset": "+08:00",
+                    "gmtTime": "19:20:00"
+                  },
+                  {
+                    "location": {
+                      "address": {
+                        "city": "Shenzhen",
+                        "countryCode": "CN",
+                        "country": "CN"
+                      },
+                      "slic": "3459"
+                    },
+                    "status": {
+                      "type": "I",
+                      "description": "Arrived at Facility",
+                      "code": "AR",
+                      "statusCode": "005"
+                    },
+                    "date": "20240319",
+                    "time": "232200",
+                    "gmtDate": "20240319",
+                    "gmtOffset": "+08:00",
+                    "gmtTime": "15:22:00"
+                  },
+                  {
+                    "location": {
+                      "address": {
+                        "city": "Koeln",
+                        "countryCode": "DE",
+                        "country": "DE"
+                      },
+                      "slic": "3459"
+                    },
+                    "status": {
+                      "type": "I",
+                      "description": "Departed from Facility",
+                      "code": "DP",
+                      "statusCode": "005"
+                    },
+                    "date": "20240319",
+                    "time": "045000",
+                    "gmtDate": "20240319",
+                    "gmtOffset": "+01:00",
+                    "gmtTime": "03:50:00"
+                  },
+                  {
+                    "location": {
+                      "address": {
+                        "city": "Koeln",
+                        "countryCode": "DE",
+                        "country": "DE"
+                      },
+                      "slic": "3468"
+                    },
+                    "status": {
+                      "type": "I",
+                      "description": "Arrived at Facility",
+                      "code": "AR",
+                      "statusCode": "005"
+                    },
+                    "date": "20240319",
+                    "time": "003400",
+                    "gmtDate": "20240318",
+                    "gmtOffset": "+01:00",
+                    "gmtTime": "23:34:00"
+                  },
+                  {
+                    "location": {
+                      "address": {
+                        "city": "Lummen",
+                        "countryCode": "BE",
+                        "country": "BE"
+                      },
+                      "slic": "3468"
+                    },
+                    "status": {
+                      "type": "I",
+                      "description": "Departed from Facility",
+                      "code": "DP",
+                      "statusCode": "005"
+                    },
+                    "date": "20240318",
+                    "time": "221000",
+                    "gmtDate": "20240318",
+                    "gmtOffset": "+01:00",
+                    "gmtTime": "21:10:00"
+                  },
+                  {
+                    "location": {
+                      "slic": "3468"
+                    },
+                    "status": {
+                      "type": "X",
+                      "description": "Your package has been released by the government agency.",
+                      "code": "RZ",
+                      "statusCode": "014"
+                    },
+                    "date": "20240318",
+                    "time": "213829",
+                    "gmtDate": "20240318",
+                    "gmtOffset": "+01:00",
+                    "gmtTime": "20:38:29"
+                  },
+                  {
+                    "location": {
+                      "address": {
+                        "city": "Lummen",
+                        "countryCode": "BE",
+                        "country": "BE"
+                      },
+                      "slic": "3468"
+                    },
+                    "status": {
+                      "type": "X",
+                      "description": "Your package is pending release from a Government Agency. Once they release it, your package will be on its way.",
+                      "code": "RZ",
+                      "statusCode": "012"
+                    },
+                    "date": "20240318",
+                    "time": "212334",
+                    "gmtDate": "20240318",
+                    "gmtOffset": "+01:00",
+                    "gmtTime": "20:23:34"
+                  },
+                  {
+                    "location": {
+                      "slic": "3468"
+                    },
+                    "status": {
+                      "type": "X",
+                      "description": "UPS has received the information needed to submit your package for clearance.",
+                      "code": "BB",
+                      "statusCode": "014"
+                    },
+                    "date": "20240318",
+                    "time": "212334",
+                    "gmtDate": "20240318",
+                    "gmtOffset": "+01:00",
+                    "gmtTime": "20:23:34"
+                  },
+                  {
+                    "location": {
+                      "address": {
+                        "city": "Lummen",
+                        "countryCode": "BE",
+                        "country": "BE"
+                      },
+                      "slic": "3468"
+                    },
+                    "status": {
+                      "type": "I",
+                      "description": "We have your package",
+                      "code": "OR",
+                      "statusCode": "005"
+                    },
+                    "date": "20240318",
+                    "time": "200306",
+                    "gmtDate": "20240318",
+                    "gmtOffset": "+01:00",
+                    "gmtTime": "19:03:06"
+                  },
+                  {
+                    "location": {
+                      "slic": "3468"
+                    },
+                    "status": {
+                      "type": "X",
+                      "description": "Your package has been released by the government agency.",
+                      "code": "RZ",
+                      "statusCode": "014"
+                    },
+                    "date": "20240318",
+                    "time": "183623",
+                    "gmtDate": "20240318",
+                    "gmtOffset": "+01:00",
+                    "gmtTime": "17:36:23"
+                  },
+                  {
+                    "location": {
+                      "address": { "city": "Lummen", "countryCode": "BE", "country": "BE" },
+                      "slic": "3468"
+                    },
+                    "status": {
+                      "type": "X",
+                      "description": "UPS initiated contact with the sender to obtain clearance information. Once received, UPS will submit for clearance.",
+                      "code": "BB",
+                      "statusCode": "058"
+                    },
+                    "date": "20240318",
+                    "time": "183623",
+                    "gmtDate": "20240318",
+                    "gmtOffset": "+01:00",
+                    "gmtTime": "17:36:23"
+                  },
+                  {
+                    "location": {
+                      "address": { "city": "Lummen", "countryCode": "BE", "country": "BE" },
+                      "slic": "3468"
+                    },
+                    "status": {
+                      "type": "X",
+                      "description": "Your package is pending release from a Government Agency. Once they release it, your package will be on its way.",
+                      "code": "RZ",
+                      "statusCode": "012"
+                    },
+                    "date": "20240318",
+                    "time": "181605",
+                    "gmtDate": "20240318",
+                    "gmtOffset": "+01:00",
+                    "gmtTime": "17:16:05"
+                  },
+                  {
+                    "location": { "slic": "3468" },
+                    "status": {
+                      "type": "X",
+                      "description": "Your package is on the way",
+                      "code": "DA",
+                      "statusCode": "014"
+                    },
+                    "date": "20240318",
+                    "time": "181605",
+                    "gmtDate": "20240318",
+                    "gmtOffset": "+01:00",
+                    "gmtTime": "17:16:05"
+                  },
+                  {
+                    "location": {
+                      "address": { "city": "Lummen", "countryCode": "BE", "country": "BE" },
+                      "slic": "3484"
+                    },
+                    "status": {
+                      "type": "P",
+                      "description": "Pickup Scan ",
+                      "code": "PU",
+                      "statusCode": "038"
+                    },
+                    "date": "20240318",
+                    "time": "154403",
+                    "gmtDate": "20240318",
+                    "gmtOffset": "+01:00",
+                    "gmtTime": "14:44:03"
+                  },
+                  {
+                    "location": {
+                      "address": { "countryCode": "BE", "country": "BE" }
+                    },
+                    "status": {
+                      "type": "M",
+                      "description": "Shipper created a label, UPS has not received the package yet. ",
+                      "code": "MP",
+                      "statusCode": "003"
+                    },
+                    "date": "20240318",
+                    "time": "124917",
+                    "gmtDate": "20240318",
+                    "gmtOffset": "+01:00",
+                    "gmtTime": "11:49:17"
+                  }
+                ],
+                "currentStatus": {
+                  "description": "Customs Clearance in Progress",
+                  "code": "092",
+                  "simplifiedTextDescription": "The package is at the clearing agency awaiting final release."
+                },
+                "packageAddress": [
+                  {
+                    "type": "ORIGIN",
+                    "address": {
+                      "city": "Brussels",
+                      "stateProvince": "",
+                      "countryCode": "BE",
+                      "country": "BE"
+                    }
+                  },
+                  {
+                    "type": "DESTINATION",
+                    "address": {
+                      "city": "CAIRNS",
+                      "stateProvince": "",
+                      "countryCode": "AU",
+                      "country": "AU"
+                    }
+                  }
+                ],
+                "weight": { "unitOfMeasurement": "KGS", "weight": "17.00" },
+                "service": { "code": "554", "levelCode": "007", "description": "UPS Express®" },
+                "referenceNumber": [
+                  { "type": "SHIPMENT", "number": "11111" },
+                  { "type": "SHIPMENT", "number": "INVOICE 11111" },
+                  { "type": "SHIPMENT", "number": "PO11111 / 11111" },
+                  { "type": "PACKAGE", "number": "INVOICE 11111" },
+                  { "type": "PACKAGE", "number": "PO11111 / 11111" }
+                ],
+                "dimension": {
+                  "height": "51.00",
+                  "length": "52.00",
+                  "width": "51.00",
+                  "unitOfDimension": "CM"
+                },
+                "packageCount": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
   end
 
   def track_ups_mi_response

--- a/spec/mock_responses.rb
+++ b/spec/mock_responses.rb
@@ -280,113 +280,113 @@ module MockResponses
 
   def track_newgistics_response
     '{
-      "Packages":[
+      "Packages" =>[
         {
-         "ActualEstimatedDeliveryDate":null,
-         "CarrierCode":"NEWG",
-         "CarrierCodeDescription":"Newgistics, Inc.",
-         "CarrierName":"United States Postal Service",
-         "CarrierService":"USPS Return Delivery Unit 5DZ",
-         "CarrierServiceCode":null,
-         "CarrierServiceCodeDescription":null,
-         "ErrorMessage":"",
-         "EstimatedDeliveryDate":null,
-         "EstimatedDeliveryText":null,
-         "FinalCarrier":null,
-         "MaxEstimatedDeliveryDate":null,
-         "MerchantName":null,
-         "MinEstimatedDeliveryDate":null,
-         "PackageTrackingEvents":[
+         "ActualEstimatedDeliveryDate" =>"null",
+         "CarrierCode" =>"NEWG",
+         "CarrierCodeDescription" =>"Newgistics, Inc.",
+         "CarrierName" =>"United States Postal Service",
+         "CarrierService" =>"USPS Return Delivery Unit 5DZ",
+         "CarrierServiceCode" =>"null",
+         "CarrierServiceCodeDescription" =>"null",
+         "ErrorMessage" =>"",
+         "EstimatedDeliveryDate" =>"null",
+         "EstimatedDeliveryText" =>"null",
+         "FinalCarrier" =>"null",
+         "MaxEstimatedDeliveryDate" =>"null",
+         "MerchantName" =>"null",
+         "MinEstimatedDeliveryDate" =>"null",
+         "PackageTrackingEvents" =>[
           {
-             "CSREventMessage":"Package delivered to returns processing facility.",
-             "CarrierCode":"SDRC",
-             "CarrierDescription":"Delivered",
-             "City":"Milwaukee",
-             "ConsumerEventMessage":"Package delivered to returns processing facility.",
-             "CreateDate":"\/Date(-62135575200000-0600)\/",
-             "Date":"\/Date(1469163600000-0500)\/",
-             "Description":"Delivered",
-             "EventCode":"DRC",
-             "EventDescription":"Delivered to Return Center",
-             "FacilityID":52687,
-             "FacilityName":"Wantable Returns",
-             "PostalCode":"53204",
-             "State":"WI",
-             "Time":"\/Date(1484870400000-0600)\/",
-             "TrackingKey":"320908566",
-             "UpdateDate":"\/Date(-62135575200000-0600)\/"
+             "CSREventMessage" =>"Package delivered to returns processing facility.",
+             "CarrierCode" =>"SDRC",
+             "CarrierDescription" =>"Delivered",
+             "City" =>"Milwaukee",
+             "ConsumerEventMessage" =>"Package delivered to returns processing facility.",
+             "CreateDate" =>"\/Date(-62135575200000-0600)\/",
+             "Date" =>"\/Date(1469163600000-0500)\/",
+             "Description" =>"Delivered",
+             "EventCode" =>"DRC",
+             "EventDescription" =>"Delivered to Return Center",
+             "FacilityID" =>52687,
+             "FacilityName" =>"Wantable Returns",
+             "PostalCode" =>"53204",
+             "State" =>"WI",
+             "Time" =>"\/Date(1484870400000-0600)\/",
+             "TrackingKey" =>"320908566",
+             "UpdateDate" =>"\/Date(-62135575200000-0600)\/"
           },
           {
-             "CSREventMessage":"Package in-transit to returns processing facility.",
-             "CarrierCode":"SS",
-             "CarrierDescription":"In transit",
-             "City":"Carol Stream",
-             "ConsumerEventMessage":"Package in-transit to returns processing facility.",
-             "CreateDate":"\/Date(-62135575200000-0600)\/",
-             "Date":"\/Date(1469077200000-0500)\/",
-             "Description":"In transit",
-             "EventCode":"DNF",
-             "EventDescription":"Departing Newgistics Facility",
-             "FacilityID":47662,
-             "FacilityName":"ORD2",
-             "PostalCode":"60188",
-             "State":"IL",
-             "Time":"\/Date(1484887140000-0600)\/",
-             "TrackingKey":"320908566",
-             "UpdateDate":"\/Date(-62135575200000-0600)\/"
+             "CSREventMessage" =>"Package in-transit to returns processing facility.",
+             "CarrierCode" =>"SS",
+             "CarrierDescription" =>"In transit",
+             "City" =>"Carol Stream",
+             "ConsumerEventMessage" =>"Package in-transit to returns processing facility.",
+             "CreateDate" =>"\/Date(-62135575200000-0600)\/",
+             "Date" =>"\/Date(1469077200000-0500)\/",
+             "Description" =>"In transit",
+             "EventCode" =>"DNF",
+             "EventDescription" =>"Departing Newgistics Facility",
+             "FacilityID" =>47662,
+             "FacilityName" =>"ORD2",
+             "PostalCode" =>"60188",
+             "State" =>"IL",
+             "Time" =>"\/Date(1484887140000-0600)\/",
+             "TrackingKey" =>"320908566",
+             "UpdateDate" =>"\/Date(-62135575200000-0600)\/"
           },
           {
-             "CSREventMessage":"Package scanned by Newgistics.",
-             "CarrierCode":"IPS",
-             "CarrierDescription":"Arrived at Shipping Facility",
-             "City":"Carol Stream",
-             "ConsumerEventMessage":"Package scanned by Newgistics.",
-             "CreateDate":"\/Date(-62135575200000-0600)\/",
-             "Date":"\/Date(1468904400000-0500)\/",
-             "Description":"Arrived at Shipping Facility",
-             "EventCode":"IPS",
-             "EventDescription":"Inducted into Newgistics Network",
-             "FacilityID":47662,
-             "FacilityName":"ORD2",
-             "PostalCode":"60188",
-             "State":"IL",
-             "Time":"\/Date(1484882280000-0600)\/",
-             "TrackingKey":"320908566",
-             "UpdateDate":"\/Date(-62135575200000-0600)\/"
+             "CSREventMessage" =>"Package scanned by Newgistics.",
+             "CarrierCode" =>"IPS",
+             "CarrierDescription" =>"Arrived at Shipping Facility",
+             "City" =>"Carol Stream",
+             "ConsumerEventMessage" =>"Package scanned by Newgistics.",
+             "CreateDate" =>"\/Date(-62135575200000-0600)\/",
+             "Date" =>"\/Date(1468904400000-0500)\/",
+             "Description" =>"Arrived at Shipping Facility",
+             "EventCode" =>"IPS",
+             "EventDescription" =>"Inducted into Newgistics Network",
+             "FacilityID" =>47662,
+             "FacilityName" =>"ORD2",
+             "PostalCode" =>"60188",
+             "State" =>"IL",
+             "Time" =>"\/Date(1484882280000-0600)\/",
+             "TrackingKey" =>"320908566",
+             "UpdateDate" =>"\/Date(-62135575200000-0600)\/"
           },
           {
-             "CSREventMessage":"Received by the USPS",
-             "CarrierCode":"PTS03",
-             "CarrierDescription":"Arrival at USPS",
-             "City":"MILWAUKEE",
-             "ConsumerEventMessage":"Received by the USPS",
-             "CreateDate":"\/Date(-62135575200000-0600)\/",
-             "Date":"\/Date(1468904400000-0500)\/",
-             "Description":"Arrival at USPS",
-             "EventCode":"PUU",
-             "EventDescription":"Picked up by USPS",
-             "FacilityID":14512,
-             "FacilityName":"WEST MILWAUKEE",
-             "PostalCode":"532195012",
-             "State":"WI",
-             "Time":"\/Date(1484829060000-0600)\/",
-             "TrackingKey":"320908566",
-             "UpdateDate":"\/Date(-62135575200000-0600)\/"
+             "CSREventMessage" =>"Received by the USPS",
+             "CarrierCode" =>"PTS03",
+             "CarrierDescription" =>"Arrival at USPS",
+             "City" =>"MILWAUKEE",
+             "ConsumerEventMessage" =>"Received by the USPS",
+             "CreateDate" =>"\/Date(-62135575200000-0600)\/",
+             "Date" =>"\/Date(1468904400000-0500)\/",
+             "Description" =>"Arrival at USPS",
+             "EventCode" =>"PUU",
+             "EventDescription" =>"Picked up by USPS",
+             "FacilityID" =>14512,
+             "FacilityName" =>"WEST MILWAUKEE",
+             "PostalCode" =>"532195012",
+             "State" =>"WI",
+             "Time" =>"\/Date(1484829060000-0600)\/",
+             "TrackingKey" =>"320908566",
+             "UpdateDate" =>"\/Date(-62135575200000-0600)\/"
           }
          ],
-         "ReferenceNumber":"000511171",
-         "Service":"RETURN",
-         "ShipToAddressLine1":"112 E Mineral Street",
-         "ShipToAddressLine2":"",
-         "ShipToCity":"Milwaukee",
-         "ShipToName":"Wantable Returns",
-         "ShipToPostalCode":"53204",
-         "ShipToState":"WI",
-         "Signer":null,
-         "Status":"Delivered",
-         "TrackingNumber":"7250053219012360010005111713",
-         "UnitOfMeasure":"pounds",
-         "Weight":3.5260
+         "ReferenceNumber" =>"000511171",
+         "Service" =>"RETURN",
+         "ShipToAddressLine1" =>"112 E Mineral Street",
+         "ShipToAddressLine2" =>"",
+         "ShipToCity" =>"Milwaukee",
+         "ShipToName" =>"Wantable Returns",
+         "ShipToPostalCode" =>"53204",
+         "ShipToState" =>"WI",
+         "Signer" =>"null",
+         "Status" =>"Delivered",
+         "TrackingNumber" =>"7250053219012360010005111713",
+         "UnitOfMeasure" =>"pounds",
+         "Weight" =>3.5260
         }
        ]
     }'
@@ -394,36 +394,36 @@ module MockResponses
 
   def track_newgistics_not_found_response
     '{
-       "Packages":[
+       "Packages" =>[
           {
-             "ActualEstimatedDeliveryDate":null,
-             "CarrierCode":null,
-             "CarrierCodeDescription":null,
-             "CarrierName":"",
-             "CarrierService":"",
-             "CarrierServiceCode":null,
-             "CarrierServiceCodeDescription":null,
-             "ErrorMessage":"No tracking data available for 9402116901279224348471blah.",
-             "EstimatedDeliveryDate":null,
-             "EstimatedDeliveryText":null,
-             "FinalCarrier":null,
-             "MaxEstimatedDeliveryDate":null,
-             "MerchantName":null,
-             "MinEstimatedDeliveryDate":null,
-             "PackageTrackingEvents":null,
-             "ReferenceNumber":null,
-             "Service":"UNKNOWN",
-             "ShipToAddressLine1":null,
-             "ShipToAddressLine2":null,
-             "ShipToCity":null,
-             "ShipToName":null,
-             "ShipToPostalCode":null,
-             "ShipToState":null,
-             "Signer":null,
-             "Status":"NotFound",
-             "TrackingNumber":"9402116901279224348471blah",
-             "UnitOfMeasure":null,
-             "Weight":null
+             "ActualEstimatedDeliveryDate" =>"null",
+             "CarrierCode" =>"null",
+             "CarrierCodeDescription" =>"null",
+             "CarrierName" =>"",
+             "CarrierService" =>"",
+             "CarrierServiceCode" =>"null",
+             "CarrierServiceCodeDescription" =>"null",
+             "ErrorMessage" =>"No tracking data available for 9402116901279224348471blah.",
+             "EstimatedDeliveryDate" =>"null",
+             "EstimatedDeliveryText" =>"null",
+             "FinalCarrier" =>"null",
+             "MaxEstimatedDeliveryDate" =>"null",
+             "MerchantName" =>"null",
+             "MinEstimatedDeliveryDate" =>"null",
+             "PackageTrackingEvents" =>"null",
+             "ReferenceNumber" =>"null",
+             "Service" =>"UNKNOWN",
+             "ShipToAddressLine1" =>"null",
+             "ShipToAddressLine2" =>"null",
+             "ShipToCity" =>"null",
+             "ShipToName" =>"null",
+             "ShipToPostalCode" =>"null",
+             "ShipToState" =>"null",
+             "Signer" =>"null",
+             "Status" =>"NotFound",
+             "TrackingNumber" =>"9402116901279224348471blah",
+             "UnitOfMeasure" =>"null",
+             "Weight" =>"null"
           }
        ]
     }'
@@ -621,369 +621,781 @@ module MockResponses
 
   def track_ups_response
     {
-      "trackResponse": {
-        "shipment": [
+      "trackResponse" => {
+        "shipment" => [
           {
-            "inquiryNumber": "1Z1202R66698804005",
-            "package": [
+            "inquiryNumber" => "1Z1202R66698804005",
+            "package" => [
               {
-                "trackingNumber": "1Z1202R66698804005",
-                "deliveryDate": [],
-                "activity": [
+                "trackingNumber" => "1Z1202R66698804005",
+                "deliveryDate" => [],
+                "activity" => [
                   {
-                    "location": {
-                      "slic": "9642"
+                    "location" => {
+                      "slic" => "9642"
                     },
-                    "status": {
-                      "type": "X",
-                      "description": "The package is at the clearing agency awaiting final release.",
-                      "statusCode": "092"
+                    "status" => {
+                      "type" => "X",
+                      "description" => "The package is at the clearing agency awaiting final release.",
+                      "statusCode" => "092"
                     },
-                    "date": "20240320",
-                    "time": "190838",
-                    "gmtDate": "20240320",
-                    "gmtOffset": "+08:00",
-                    "gmtTime": "11:08:38"
+                    "date" => "20240320",
+                    "time" => "190838",
+                    "gmtDate" => "20240320",
+                    "gmtOffset" => "+08:00",
+                    "gmtTime" => "11:08:38"
                   },
                   {
-                    "location": {
-                      "address": {
-                        "city": "Changi",
-                        "countryCode": "SG",
-                        "country": "SG"
+                    "location" => {
+                      "address" => {
+                        "city" => "Changi",
+                        "countryCode" => "SG",
+                        "country" => "SG"
                       },
-                      "slic": "0009"
+                      "slic" => "0009"
                     },
-                    "status": {
-                      "type": "I",
-                      "description": "Arrived at Facility",
-                      "code": "AR",
-                      "statusCode": "005"
+                    "status" => {
+                      "type" => "I",
+                      "description" => "Arrived at Facility",
+                      "code" => "AR",
+                      "statusCode" => "005"
                     },
-                    "date": "20240320",
-                    "time": "070700",
-                    "gmtDate": "20240319",
-                    "gmtOffset": "+08:00",
-                    "gmtTime": "23:07:00"
+                    "date" => "20240320",
+                    "time" => "070700",
+                    "gmtDate" => "20240319",
+                    "gmtOffset" => "+08:00",
+                    "gmtTime" => "23:07:00"
                   },
                   {
-                    "location": {
-                      "address": {
-                        "city": "Shenzhen",
-                        "countryCode": "CN",
-                        "country": "CN"
+                    "location" => {
+                      "address" => {
+                        "city" => "Shenzhen",
+                        "countryCode" => "CN",
+                        "country" => "CN"
                       },
-                      "slic": "0009"
+                      "slic" => "0009"
                     },
-                    "status": {
-                      "type": "I",
-                      "description": "Departed from Facility",
-                      "code": "DP",
-                      "statusCode": "005"
+                    "status" => {
+                      "type" => "I",
+                      "description" => "Departed from Facility",
+                      "code" => "DP",
+                      "statusCode" => "005"
                     },
-                    "date": "20240320",
-                    "time": "032000",
-                    "gmtDate": "20240319",
-                    "gmtOffset": "+08:00",
-                    "gmtTime": "19:20:00"
+                    "date" => "20240320",
+                    "time" => "032000",
+                    "gmtDate" => "20240319",
+                    "gmtOffset" => "+08:00",
+                    "gmtTime" => "19:20:00"
                   },
                   {
-                    "location": {
-                      "address": {
-                        "city": "Shenzhen",
-                        "countryCode": "CN",
-                        "country": "CN"
+                    "location" => {
+                      "address" => {
+                        "city" => "Shenzhen",
+                        "countryCode" => "CN",
+                        "country" => "CN"
                       },
-                      "slic": "3459"
+                      "slic" => "3459"
                     },
-                    "status": {
-                      "type": "I",
-                      "description": "Arrived at Facility",
-                      "code": "AR",
-                      "statusCode": "005"
+                    "status" => {
+                      "type" => "I",
+                      "description" => "Arrived at Facility",
+                      "code" => "AR",
+                      "statusCode" => "005"
                     },
-                    "date": "20240319",
-                    "time": "232200",
-                    "gmtDate": "20240319",
-                    "gmtOffset": "+08:00",
-                    "gmtTime": "15:22:00"
+                    "date" => "20240319",
+                    "time" => "232200",
+                    "gmtDate" => "20240319",
+                    "gmtOffset" => "+08:00",
+                    "gmtTime" => "15:22:00"
                   },
                   {
-                    "location": {
-                      "address": {
-                        "city": "Koeln",
-                        "countryCode": "DE",
-                        "country": "DE"
+                    "location" => {
+                      "address" => {
+                        "city" => "Koeln",
+                        "countryCode" => "DE",
+                        "country" => "DE"
                       },
-                      "slic": "3459"
+                      "slic" => "3459"
                     },
-                    "status": {
-                      "type": "I",
-                      "description": "Departed from Facility",
-                      "code": "DP",
-                      "statusCode": "005"
+                    "status" => {
+                      "type" => "I",
+                      "description" => "Departed from Facility",
+                      "code" => "DP",
+                      "statusCode" => "005"
                     },
-                    "date": "20240319",
-                    "time": "045000",
-                    "gmtDate": "20240319",
-                    "gmtOffset": "+01:00",
-                    "gmtTime": "03:50:00"
+                    "date" => "20240319",
+                    "time" => "045000",
+                    "gmtDate" => "20240319",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "03:50:00"
                   },
                   {
-                    "location": {
-                      "address": {
-                        "city": "Koeln",
-                        "countryCode": "DE",
-                        "country": "DE"
+                    "location" => {
+                      "address" => {
+                        "city" => "Koeln",
+                        "countryCode" => "DE",
+                        "country" => "DE"
                       },
-                      "slic": "3468"
+                      "slic" => "3468"
                     },
-                    "status": {
-                      "type": "I",
-                      "description": "Arrived at Facility",
-                      "code": "AR",
-                      "statusCode": "005"
+                    "status" => {
+                      "type" => "I",
+                      "description" => "Arrived at Facility",
+                      "code" => "AR",
+                      "statusCode" => "005"
                     },
-                    "date": "20240319",
-                    "time": "003400",
-                    "gmtDate": "20240318",
-                    "gmtOffset": "+01:00",
-                    "gmtTime": "23:34:00"
+                    "date" => "20240319",
+                    "time" => "003400",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "23:34:00"
                   },
                   {
-                    "location": {
-                      "address": {
-                        "city": "Lummen",
-                        "countryCode": "BE",
-                        "country": "BE"
+                    "location" => {
+                      "address" => {
+                        "city" => "Lummen",
+                        "countryCode" => "BE",
+                        "country" => "BE"
                       },
-                      "slic": "3468"
+                      "slic" => "3468"
                     },
-                    "status": {
-                      "type": "I",
-                      "description": "Departed from Facility",
-                      "code": "DP",
-                      "statusCode": "005"
+                    "status" => {
+                      "type" => "I",
+                      "description" => "Departed from Facility",
+                      "code" => "DP",
+                      "statusCode" => "005"
                     },
-                    "date": "20240318",
-                    "time": "221000",
-                    "gmtDate": "20240318",
-                    "gmtOffset": "+01:00",
-                    "gmtTime": "21:10:00"
+                    "date" => "20240318",
+                    "time" => "221000",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "21:10:00"
                   },
                   {
-                    "location": {
-                      "slic": "3468"
+                    "location" => {
+                      "slic" => "3468"
                     },
-                    "status": {
-                      "type": "X",
-                      "description": "Your package has been released by the government agency.",
-                      "code": "RZ",
-                      "statusCode": "014"
+                    "status" => {
+                      "type" => "X",
+                      "description" => "Your package has been released by the government agency.",
+                      "code" => "RZ",
+                      "statusCode" => "014"
                     },
-                    "date": "20240318",
-                    "time": "213829",
-                    "gmtDate": "20240318",
-                    "gmtOffset": "+01:00",
-                    "gmtTime": "20:38:29"
+                    "date" => "20240318",
+                    "time" => "213829",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "20:38:29"
                   },
                   {
-                    "location": {
-                      "address": {
-                        "city": "Lummen",
-                        "countryCode": "BE",
-                        "country": "BE"
+                    "location" => {
+                      "address" => {
+                        "city" => "Lummen",
+                        "countryCode" => "BE",
+                        "country" => "BE"
                       },
-                      "slic": "3468"
+                      "slic" => "3468"
                     },
-                    "status": {
-                      "type": "X",
-                      "description": "Your package is pending release from a Government Agency. Once they release it, your package will be on its way.",
-                      "code": "RZ",
-                      "statusCode": "012"
+                    "status" => {
+                      "type" => "X",
+                      "description" => "Your package is pending release from a Government Agency. Once they release it, your package will be on its way.",
+                      "code" => "RZ",
+                      "statusCode" => "012"
                     },
-                    "date": "20240318",
-                    "time": "212334",
-                    "gmtDate": "20240318",
-                    "gmtOffset": "+01:00",
-                    "gmtTime": "20:23:34"
+                    "date" => "20240318",
+                    "time" => "212334",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "20:23:34"
                   },
                   {
-                    "location": {
-                      "slic": "3468"
+                    "location" => {
+                      "slic" => "3468"
                     },
-                    "status": {
-                      "type": "X",
-                      "description": "UPS has received the information needed to submit your package for clearance.",
-                      "code": "BB",
-                      "statusCode": "014"
+                    "status" => {
+                      "type" => "X",
+                      "description" => "UPS has received the information needed to submit your package for clearance.",
+                      "code" => "BB",
+                      "statusCode" => "014"
                     },
-                    "date": "20240318",
-                    "time": "212334",
-                    "gmtDate": "20240318",
-                    "gmtOffset": "+01:00",
-                    "gmtTime": "20:23:34"
+                    "date" => "20240318",
+                    "time" => "212334",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "20:23:34"
                   },
                   {
-                    "location": {
-                      "address": {
-                        "city": "Lummen",
-                        "countryCode": "BE",
-                        "country": "BE"
+                    "location" => {
+                      "address" => {
+                        "city" => "Lummen",
+                        "countryCode" => "BE",
+                        "country" => "BE"
                       },
-                      "slic": "3468"
+                      "slic" => "3468"
                     },
-                    "status": {
-                      "type": "I",
-                      "description": "We have your package",
-                      "code": "OR",
-                      "statusCode": "005"
+                    "status" => {
+                      "type" => "I",
+                      "description" => "We have your package",
+                      "code" => "OR",
+                      "statusCode" => "005"
                     },
-                    "date": "20240318",
-                    "time": "200306",
-                    "gmtDate": "20240318",
-                    "gmtOffset": "+01:00",
-                    "gmtTime": "19:03:06"
+                    "date" => "20240318",
+                    "time" => "200306",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "19:03:06"
                   },
                   {
-                    "location": {
-                      "slic": "3468"
+                    "location" => {
+                      "slic" => "3468"
                     },
-                    "status": {
-                      "type": "X",
-                      "description": "Your package has been released by the government agency.",
-                      "code": "RZ",
-                      "statusCode": "014"
+                    "status" => {
+                      "type" => "X",
+                      "description" => "Your package has been released by the government agency.",
+                      "code" => "RZ",
+                      "statusCode" => "014"
                     },
-                    "date": "20240318",
-                    "time": "183623",
-                    "gmtDate": "20240318",
-                    "gmtOffset": "+01:00",
-                    "gmtTime": "17:36:23"
+                    "date" => "20240318",
+                    "time" => "183623",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "17:36:23"
                   },
                   {
-                    "location": {
-                      "address": { "city": "Lummen", "countryCode": "BE", "country": "BE" },
-                      "slic": "3468"
+                    "location" => {
+                      "address" => { "city" => "Lummen", "countryCode" => "BE", "country" => "BE" },
+                      "slic" => "3468"
                     },
-                    "status": {
-                      "type": "X",
-                      "description": "UPS initiated contact with the sender to obtain clearance information. Once received, UPS will submit for clearance.",
-                      "code": "BB",
-                      "statusCode": "058"
+                    "status" => {
+                      "type" => "X",
+                      "description" => "UPS initiated contact with the sender to obtain clearance information. Once received, UPS will submit for clearance.",
+                      "code" => "BB",
+                      "statusCode" => "058"
                     },
-                    "date": "20240318",
-                    "time": "183623",
-                    "gmtDate": "20240318",
-                    "gmtOffset": "+01:00",
-                    "gmtTime": "17:36:23"
+                    "date" => "20240318",
+                    "time" => "183623",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "17:36:23"
                   },
                   {
-                    "location": {
-                      "address": { "city": "Lummen", "countryCode": "BE", "country": "BE" },
-                      "slic": "3468"
+                    "location" => {
+                      "address" => { "city" => "Lummen", "countryCode" => "BE", "country" => "BE" },
+                      "slic" => "3468"
                     },
-                    "status": {
-                      "type": "X",
-                      "description": "Your package is pending release from a Government Agency. Once they release it, your package will be on its way.",
-                      "code": "RZ",
-                      "statusCode": "012"
+                    "status" => {
+                      "type" => "X",
+                      "description" => "Your package is pending release from a Government Agency. Once they release it, your package will be on its way.",
+                      "code" => "RZ",
+                      "statusCode" => "012"
                     },
-                    "date": "20240318",
-                    "time": "181605",
-                    "gmtDate": "20240318",
-                    "gmtOffset": "+01:00",
-                    "gmtTime": "17:16:05"
+                    "date" => "20240318",
+                    "time" => "181605",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "17:16:05"
                   },
                   {
-                    "location": { "slic": "3468" },
-                    "status": {
-                      "type": "X",
-                      "description": "Your package is on the way",
-                      "code": "DA",
-                      "statusCode": "014"
+                    "location" => { "slic" => "3468" },
+                    "status" => {
+                      "type" => "X",
+                      "description" => "Your package is on the way",
+                      "code" => "DA",
+                      "statusCode" => "014"
                     },
-                    "date": "20240318",
-                    "time": "181605",
-                    "gmtDate": "20240318",
-                    "gmtOffset": "+01:00",
-                    "gmtTime": "17:16:05"
+                    "date" => "20240318",
+                    "time" => "181605",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "17:16:05"
                   },
                   {
-                    "location": {
-                      "address": { "city": "Lummen", "countryCode": "BE", "country": "BE" },
-                      "slic": "3484"
+                    "location" => {
+                      "address" => { "city" => "Lummen", "countryCode" => "BE", "country" => "BE" },
+                      "slic" => "3484"
                     },
-                    "status": {
-                      "type": "P",
-                      "description": "Pickup Scan ",
-                      "code": "PU",
-                      "statusCode": "038"
+                    "status" => {
+                      "type" => "P",
+                      "description" => "Pickup Scan ",
+                      "code" => "PU",
+                      "statusCode" => "038"
                     },
-                    "date": "20240318",
-                    "time": "154403",
-                    "gmtDate": "20240318",
-                    "gmtOffset": "+01:00",
-                    "gmtTime": "14:44:03"
+                    "date" => "20240318",
+                    "time" => "154403",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "14:44:03"
                   },
                   {
-                    "location": {
-                      "address": { "countryCode": "BE", "country": "BE" }
+                    "location" => {
+                      "address" => { "countryCode" => "BE", "country" => "BE" }
                     },
-                    "status": {
-                      "type": "M",
-                      "description": "Shipper created a label, UPS has not received the package yet. ",
-                      "code": "MP",
-                      "statusCode": "003"
+                    "status" => {
+                      "type" => "M",
+                      "description" => "Shipper created a label, UPS has not received the package yet. ",
+                      "code" => "MP",
+                      "statusCode" => "003"
                     },
-                    "date": "20240318",
-                    "time": "124917",
-                    "gmtDate": "20240318",
-                    "gmtOffset": "+01:00",
-                    "gmtTime": "11:49:17"
+                    "date" => "20240318",
+                    "time" => "124917",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "11:49:17"
                   }
                 ],
-                "currentStatus": {
-                  "description": "Customs Clearance in Progress",
-                  "code": "092",
-                  "simplifiedTextDescription": "The package is at the clearing agency awaiting final release."
+                "currentStatus" => {
+                  "description" => "Customs Clearance in Progress",
+                  "code" => "092",
+                  "simplifiedTextDescription" => "The package is at the clearing agency awaiting final release."
                 },
-                "packageAddress": [
+                "packageAddress" => [
                   {
-                    "type": "ORIGIN",
-                    "address": {
-                      "city": "Brussels",
-                      "stateProvince": "",
-                      "countryCode": "BE",
-                      "country": "BE"
+                    "type" => "ORIGIN",
+                    "address" => {
+                      "city" => "Brussels",
+                      "stateProvince" => "",
+                      "countryCode" => "BE",
+                      "country" => "BE"
                     }
                   },
                   {
-                    "type": "DESTINATION",
-                    "address": {
-                      "city": "CAIRNS",
-                      "stateProvince": "",
-                      "countryCode": "AU",
-                      "country": "AU"
+                    "type" => "DESTINATION",
+                    "address" => {
+                      "city" => "CAIRNS",
+                      "stateProvince" => "",
+                      "countryCode" => "AU",
+                      "country" => "AU"
                     }
                   }
                 ],
-                "weight": { "unitOfMeasurement": "KGS", "weight": "17.00" },
-                "service": { "code": "554", "levelCode": "007", "description": "UPS Express®" },
-                "referenceNumber": [
-                  { "type": "SHIPMENT", "number": "11111" },
-                  { "type": "SHIPMENT", "number": "INVOICE 11111" },
-                  { "type": "SHIPMENT", "number": "PO11111 / 11111" },
-                  { "type": "PACKAGE", "number": "INVOICE 11111" },
-                  { "type": "PACKAGE", "number": "PO11111 / 11111" }
+                "weight" => { "unitOfMeasurement" => "KGS", "weight" => "17.00" },
+                "service" => { "code" => "554", "levelCode" => "007", "description" => "UPS Express®" },
+                "referenceNumber" => [
+                  { "type" => "SHIPMENT", "number" => "11111" },
+                  { "type" => "SHIPMENT", "number" => "INVOICE 11111" },
+                  { "type" => "SHIPMENT", "number" => "PO11111 / 11111" },
+                  { "type" => "PACKAGE", "number" => "INVOICE 11111" },
+                  { "type" => "PACKAGE", "number" => "PO11111 / 11111" }
                 ],
-                "dimension": {
-                  "height": "51.00",
-                  "length": "52.00",
-                  "width": "51.00",
-                  "unitOfDimension": "CM"
+                "dimension" => {
+                  "height" => "51.00",
+                  "length" => "52.00",
+                  "width" => "51.00",
+                  "unitOfDimension" => "CM"
                 },
-                "packageCount": 1
+                "packageCount" => 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  end
+
+  def track_ups_left_not_arrived
+    {
+      "trackResponse" => {
+        "shipment" => [
+          {
+            "inquiryNumber" => "1Z1202R66698804005",
+            "package" => [
+              {
+                "trackingNumber" => "1Z1202R66698804005",
+                "deliveryDate" => [],
+                "activity" => [
+                  {
+                    "location" => {
+                      "slic" => "9642"
+                    },
+                    "status" => {
+                      "type" => "X",
+                      "description" => "The package is at the clearing agency awaiting final release.",
+                      "statusCode" => "092"
+                    },
+                    "date" => "20240320",
+                    "time" => "190838",
+                    "gmtDate" => "20240320",
+                    "gmtOffset" => "+08:00",
+                    "gmtTime" => "11:08:38"
+                  },
+                  {
+                    "location" => {
+                      "address" => {
+                        "city" => "Changi",
+                        "countryCode" => "SG",
+                        "country" => "SG"
+                      },
+                      "slic" => "0009"
+                    },
+                    "status" => {
+                      "type" => "I",
+                      "description" => "Arrived at Facility",
+                      "code" => "AR",
+                      "statusCode" => "005"
+                    },
+                    "date" => "20240320",
+                    "time" => "070700",
+                    "gmtDate" => "20240319",
+                    "gmtOffset" => "+08:00",
+                    "gmtTime" => "23:07:00"
+                  },
+                  {
+                    "location" => {
+                      "address" => {
+                        "city" => "Shenzhen",
+                        "countryCode" => "CN",
+                        "country" => "CN"
+                      },
+                      "slic" => "0009"
+                    },
+                    "status" => {
+                      "type" => "I",
+                      "description" => "Departed from Facility",
+                      "code" => "DP",
+                      "statusCode" => "005"
+                    },
+                    "date" => "20240320",
+                    "time" => "032000",
+                    "gmtDate" => "20240319",
+                    "gmtOffset" => "+08:00",
+                    "gmtTime" => "19:20:00"
+                  },
+                  {
+                    "location" => {
+                      "address" => {
+                        "city" => "Shenzhen",
+                        "countryCode" => "CN",
+                        "country" => "CN"
+                      },
+                      "slic" => "3459"
+                    },
+                    "status" => {
+                      "type" => "I",
+                      "description" => "Arrived at Facility",
+                      "code" => "AR",
+                      "statusCode" => "005"
+                    },
+                    "date" => "20240319",
+                    "time" => "232200",
+                    "gmtDate" => "20240319",
+                    "gmtOffset" => "+08:00",
+                    "gmtTime" => "15:22:00"
+                  },
+                  {
+                    "location" => {
+                      "address" => {
+                        "city" => "Koeln",
+                        "countryCode" => "DE",
+                        "country" => "DE"
+                      },
+                      "slic" => "3459"
+                    },
+                    "status" => {
+                      "type" => "I",
+                      "description" => "Departed from Facility",
+                      "code" => "DP",
+                      "statusCode" => "005"
+                    },
+                    "date" => "20240319",
+                    "time" => "045000",
+                    "gmtDate" => "20240319",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "03:50:00"
+                  },
+                  {
+                    "location" => {
+                      "address" => {
+                        "city" => "Koeln",
+                        "countryCode" => "DE",
+                        "country" => "DE"
+                      },
+                      "slic" => "3468"
+                    },
+                    "status" => {
+                      "type" => "I",
+                      "description" => "Arrived at Facility",
+                      "code" => "AR",
+                      "statusCode" => "005"
+                    },
+                    "date" => "20240319",
+                    "time" => "003400",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "23:34:00"
+                  },
+                  {
+                    "location" => {
+                      "address" => {
+                        "city" => "Lummen",
+                        "countryCode" => "BE",
+                        "country" => "BE"
+                      },
+                      "slic" => "3468"
+                    },
+                    "status" => {
+                      "type" => "I",
+                      "description" => "Departed from Facility",
+                      "code" => "DP",
+                      "statusCode" => "005"
+                    },
+                    "date" => "20240318",
+                    "time" => "221000",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "21:10:00"
+                  },
+                  {
+                    "location" => {
+                      "slic" => "3468"
+                    },
+                    "status" => {
+                      "type" => "X",
+                      "description" => "Your package has been released by the government agency.",
+                      "code" => "RZ",
+                      "statusCode" => "014"
+                    },
+                    "date" => "20240318",
+                    "time" => "213829",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "20:38:29"
+                  },
+                  {
+                    "location" => {
+                      "address" => {
+                        "city" => "Lummen",
+                        "countryCode" => "BE",
+                        "country" => "BE"
+                      },
+                      "slic" => "3468"
+                    },
+                    "status" => {
+                      "type" => "X",
+                      "description" => "Your package is pending release from a Government Agency. Once they release it, your package will be on its way.",
+                      "code" => "RZ",
+                      "statusCode" => "012"
+                    },
+                    "date" => "20240318",
+                    "time" => "212334",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "20:23:34"
+                  },
+                  {
+                    "location" => {
+                      "slic" => "3468"
+                    },
+                    "status" => {
+                      "type" => "X",
+                      "description" => "UPS has received the information needed to submit your package for clearance.",
+                      "code" => "BB",
+                      "statusCode" => "014"
+                    },
+                    "date" => "20240318",
+                    "time" => "212334",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "20:23:34"
+                  },
+                  {
+                    "location" => {
+                      "address" => {
+                        "city" => "Lummen",
+                        "countryCode" => "BE",
+                        "country" => "BE"
+                      },
+                      "slic" => "3468"
+                    },
+                    "status" => {
+                      "type" => "I",
+                      "description" => "We have your package",
+                      "code" => "OR",
+                      "statusCode" => "005"
+                    },
+                    "date" => "20240318",
+                    "time" => "200306",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "19:03:06"
+                  },
+                  {
+                    "location" => {
+                      "slic" => "3468"
+                    },
+                    "status" => {
+                      "type" => "X",
+                      "description" => "Your package has been released by the government agency.",
+                      "code" => "RZ",
+                      "statusCode" => "014"
+                    },
+                    "date" => "20240318",
+                    "time" => "183623",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "17:36:23"
+                  },
+                  {
+                    "location" => {
+                      "address" => {
+                        "city" => "Lummen",
+                        "countryCode" => "BE",
+                        "country" => "BE"
+                      },
+                      "slic" => "3468"
+                    },
+                    "status" => {
+                      "type" => "X",
+                      "description" => "UPS initiated contact with the sender to obtain clearance information. Once received, UPS will submit for clearance.",
+                      "code" => "BB",
+                      "statusCode" => "058"
+                    },
+                    "date" => "20240318",
+                    "time" => "183623",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "17:36:23"
+                  },
+                  {
+                    "location" => {
+                      "address" => {
+                        "city" => "Lummen",
+                        "countryCode" => "BE",
+                        "country" => "BE"
+                      },
+                      "slic" => "3468"
+                    },
+                    "status" => {
+                      "type" => "X",
+                      "description" => "Your package is pending release from a Government Agency. Once they release it, your package will be on its way.",
+                      "code" => "RZ",
+                      "statusCode" => "012"
+                    },
+                    "date" => "20240318",
+                    "time" => "181605",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "17:16:05"
+                  },
+                  {
+                    "location" => {
+                      "slic" => "3468"
+                    },
+                    "status" => {
+                      "type" => "X",
+                      "description" => "Your package is on the way",
+                      "code" => "DA",
+                      "statusCode" => "014"
+                    },
+                    "date" => "20240318",
+                    "time" => "181605",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "17:16:05"
+                  },
+                  {
+                    "location" => {
+                      "address" => {
+                        "city" => "Lummen",
+                        "countryCode" => "BE",
+                        "country" => "BE"
+                      },
+                      "slic" => "3484"
+                    },
+                    "status" => {
+                      "type" => "P",
+                      "description" => "Pickup Scan ",
+                      "code" => "PU",
+                      "statusCode" => "038"
+                    },
+                    "date" => "20240318",
+                    "time" => "154403",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "14:44:03"
+                  },
+                  {
+                    "location" => {
+                      "address" => {
+                        "countryCode" => "BE",
+                        "country" => "BE"
+                      }
+                    },
+                    "status" => {
+                      "type" => "M",
+                      "description" => "Shipper created a label, UPS has not received the package yet. ",
+                      "code" => "MP",
+                      "statusCode" => "003"
+                    },
+                    "date" => "20240318",
+                    "time" => "124917",
+                    "gmtDate" => "20240318",
+                    "gmtOffset" => "+01:00",
+                    "gmtTime" => "11:49:17"
+                  }
+                ],
+                "currentStatus" => {
+                  "description" => "Customs Clearance in Progress",
+                  "code" => "092",
+                  "simplifiedTextDescription" => "The package is at the clearing agency awaiting final release."
+                },
+                "packageAddress" => [
+                  {
+                    "type" => "ORIGIN",
+                    "address" => {
+                      "city" => "Brussels",
+                      "stateProvince" => "",
+                      "countryCode" => "BE",
+                      "country" => "BE"
+                    }
+                  },
+                  {
+                    "type" => "DESTINATION",
+                    "address" => {
+                      "city" => "CAIRNS",
+                      "stateProvince" => "",
+                      "countryCode" => "AU",
+                      "country" => "AU"
+                    }
+                  }
+                ],
+                "weight" => {
+                  "unitOfMeasurement" => "KGS",
+                  "weight" => "17.00"
+                },
+                "service" => {
+                  "code" => "554",
+                  "levelCode" => "007",
+                  "description" => "UPS Express®"
+                },
+                "referenceNumber" => [
+                  {
+                    "type" => "SHIPMENT",
+                    "number" => "1202R6ZZZZZ"
+                  },
+                  {
+                    "type" => "SHIPMENT",
+                    "number" => "INVOICE 3000010221"
+                  },
+                  {
+                    "type" => "SHIPMENT",
+                    "number" => "PO22235 / 338343000"
+                  },
+                  {
+                    "type" => "PACKAGE",
+                    "number" => "INVOICE 3000043391"
+                  },
+                  {
+                    "type" => "PACKAGE",
+                    "number" => "PO22000 / 338343000"
+                  }
+                ],
+                "dimension" => {
+                  "height" => "51.00",
+                  "length" => "52.00",
+                  "width" => "51.00",
+                  "unitOfDimension" => "CM"
+                },
+                "packageCount" => 1
               }
             ]
           }
@@ -993,372 +1405,146 @@ module MockResponses
   end
 
   def track_ups_mi_response
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-    <TrackResponse>
-      <Response>
-        <TransactionReference>
-          <CustomerContext>ad037137-1281-4e73-9260-0b681485657a</CustomerContext>
-          <XpciVersion>1.0</XpciVersion>
-        </TransactionReference>
-        <ResponseStatusCode>1</ResponseStatusCode>
-        <ResponseStatusDescription>Success</ResponseStatusDescription>
-      </Response>
-      <Shipment>
-        <InquiryNumber>
-          <Code>03</Code>
-          <Description>Mail Innovations Tracking Number</Description>
-          <Value>801677101298096996</Value>
-        </InquiryNumber>
-        <ShipmentType>
-          <Code>03</Code>
-          <Description>Mail Innovations</Description>
-        </ShipmentType>
-        <Shipper>
-          <Address>
-            <City>Milwauke</City>
-            <StateProvinceCode>WI</StateProvinceCode>
-            <PostalCode>53204</PostalCode>
-            <CountryCode>US</CountryCode>
-          </Address>
-        </Shipper>
-        <ShipTo>
-          <Address>
-            <City>DUNWOODY</City>
-            <StateProvinceCode>GA</StateProvinceCode>
-            <PostalCode>30338</PostalCode>
-            <CountryCode>US</CountryCode>
-          </Address>
-        </ShipTo>
-        <ShipmentWeight>
-          <UnitOfMeasurement>
-            <Code>LBS</Code>
-          </UnitOfMeasurement>
-          <Weight>0.5050</Weight>
-        </ShipmentWeight>
-        <Service>
-          <Code>702</Code>
-          <Description>UPS Mail Innovations Expedited</Description>
-        </Service>
-        <ReferenceNumber>
-          <Code>96</Code>
-          <Value>W025284315C226</Value>
-        </ReferenceNumber>
-        <PickupDate>20170112</PickupDate>
-        <DeliveryDateTime>
-          <Type>
-            <Code>01</Code>
-            <Description>Delivery</Description>
-          </Type>
-          <Date>20170116</Date>
-          <Time>1314</Time>
-        </DeliveryDateTime>
-        <Package>
-          <TrackingNumber>801677101298096996</TrackingNumber>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>Atlanta</City>
-                <StateProvinceCode>GA</StateProvinceCode>
-                <PostalCode>30338</PostalCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-              <TransportFacility>
-                <Type>IC</Type>
-              </TransportFacility>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>D</Code>
-                <Description>Package delivered by post office</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>D</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170116</Date>
-            <Time>1314</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>Atlanta</City>
-                <StateProvinceCode>GA</StateProvinceCode>
-                <PostalCode>30338</PostalCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-              <TransportFacility>
-                <Type>VT</Type>
-                <Code>GATLA</Code>
-              </TransportFacility>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>Package transferred to post office</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>I</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170114</Date>
-            <Time>1511</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>Morrow</City>
-                <StateProvinceCode>GA</StateProvinceCode>
-                <PostalCode>30260</PostalCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-              <TransportFacility>
-                <Type>VT</Type>
-                <Code>GATLA</Code>
-              </TransportFacility>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>Package departed UPS Mail Innovations facility enroute to USPS for induction</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>I</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170114</Date>
-            <Time>1022</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>Morrow</City>
-                <StateProvinceCode>GA</StateProvinceCode>
-                <PostalCode>30260</PostalCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-              <TransportFacility>
-                <Type>VT</Type>
-                <Code>GATLA</Code>
-              </TransportFacility>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>Postage Paid/Ready for destination post office entry</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>I</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170114</Date>
-            <Time>1018</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>Atlanta</City>
-                <StateProvinceCode>GA</StateProvinceCode>
-                <PostalCode>30338</PostalCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-              <TransportFacility>
-                <Type>IC</Type>
-              </TransportFacility>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>Electronic Shipment Information Received for Package by Post Office</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>I</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170114</Date>
-            <Time>0947</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>Morrow</City>
-                <StateProvinceCode>GA</StateProvinceCode>
-                <PostalCode>30260</PostalCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-              <TransportFacility>
-                <Type>VT</Type>
-                <Code>GATLA</Code>
-              </TransportFacility>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>Package received for sort by destination UPS Mail Innovations facility</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>I</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170114</Date>
-            <Time>0650</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>Bensenville</City>
-                <StateProvinceCode>IL</StateProvinceCode>
-                <PostalCode>60106</PostalCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-              <TransportFacility>
-                <Type>VT</Type>
-                <Code>ILCST</Code>
-              </TransportFacility>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>Package transferred to destination UPS Mail Innovations facility</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>I</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170113</Date>
-            <Time>0721</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>Bensenville</City>
-                <StateProvinceCode>IL</StateProvinceCode>
-                <PostalCode>60106</PostalCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-              <TransportFacility>
-                <Type>VT</Type>
-                <Code>ILCST</Code>
-              </TransportFacility>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>Package processed by UPS Mail Innovations origin facility</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>I</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170113</Date>
-            <Time>0043</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>Bensenville</City>
-                <StateProvinceCode>IL</StateProvinceCode>
-                <PostalCode>60106</PostalCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-              <TransportFacility>
-                <Type>VT</Type>
-                <Code>ILCST</Code>
-              </TransportFacility>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>I</Code>
-                <Description>Package received for processing by UPS Mail Innovations</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>I</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170113</Date>
-            <Time>0005</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <City>Milwauke</City>
-                <StateProvinceCode>WI</StateProvinceCode>
-                <PostalCode>53204</PostalCode>
-                <CountryCode>US</CountryCode>
-              </Address>
-              <TransportFacility>
-                <Type>VT</Type>
-                <Code>ILCST</Code>
-              </TransportFacility>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>P</Code>
-                <Description>Shipment tendered to UPS Mail Innovations</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>P</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170112</Date>
-            <Time>2353</Time>
-          </Activity>
-          <Activity>
-            <ActivityLocation>
-              <Address>
-                <CountryCode>US</CountryCode>
-              </Address>
-              <TransportFacility>
-                <Type>VT</Type>
-              </TransportFacility>
-            </ActivityLocation>
-            <Status>
-              <StatusType>
-                <Code>M</Code>
-                <Description>Shipment information received by UPS Mail Innovations</Description>
-              </StatusType>
-              <StatusCode>
-                <Code>M</Code>
-              </StatusCode>
-            </Status>
-            <Date>20170112</Date>
-            <Time>1553</Time>
-          </Activity>
-          <PackageWeight>
-            <UnitOfMeasurement>
-              <Code>LBS</Code>
-            </UnitOfMeasurement>
-            <Weight>0.5050</Weight>
-          </PackageWeight>
-          <ReferenceNumber>
-            <Code>96</Code>
-            <Value>W025284315C226</Value>
-          </ReferenceNumber>
-          <AlternateTrackingInfo>
-            <Type>Q</Type>
-            <Value>92748999964209543475518096</Value>
-          </AlternateTrackingInfo>
-        </Package>
-      </Shipment>
-    </TrackResponse>"
+    {
+      "trackResponse" => {
+        "shipment" => [
+          {
+            "inquiryNumber" => "1Z023E2X0214323462",
+            "package" => [
+              {
+                "accessPointInformation" => {
+                  "pickupByDate" => "string"
+                },
+                "activity" => [
+                  {
+                    "date" => "null",
+                    "gmtDate" => "null",
+                    "gmtOffset" => "null",
+                    "gmtTime" => "null",
+                    "location" => "null",
+                    "status" => "null",
+                    "time" => "null"
+                  }
+                ],
+                "additionalAttributes" => [
+                  "SENSOR_EVENT"
+                ],
+                "additionalServices" => [
+                  "ADULT_SIGNATURE_REQUIRED",
+                  "SIGNATURE_REQUIRED",
+                  "ADDITIONAL_HANDLING",
+                  "CARBON_NEUTRAL",
+                  "UPS_PREMIER_SILVER",
+                  "UPS_PREMIER_GOLD",
+                  "UPS_PREMIER_PLATINUM"
+                ],
+                "alternateTrackingNumber" => [
+                  {
+                    "number" => "null",
+                    "type" => "null"
+                  }
+                ],
+                "currentStatus" => {
+                  "code" => "SR",
+                  "description" => "Your package was released by the customs agency.",
+                  "simplifiedTextDescription" => "Delivered",
+                  "statusCode" => "003",
+                  "type" => "X"
+                },
+                "deliveryDate" => [
+                  {
+                    "date" => "null",
+                    "type" => "null"
+                  }
+                ],
+                "deliveryInformation" => {
+                  "location" => "Front Door",
+                  "receivedBy" => "",
+                  "signature" => {
+                    "image" => "null"
+                  },
+                  "pod" => {
+                    "content" => "null"
+                  }
+                },
+                "deliveryTime" => {
+                  "endTime" => "string",
+                  "startTime" => "string",
+                  "type" => "string"
+                },
+                "milestones" => [
+                  {
+                    "category" => "null",
+                    "code" => "null",
+                    "current" => "null",
+                    "description" => "null",
+                    "linkedActivity" => "null",
+                    "state" => "null",
+                    "subMilestone" => "null"
+                  }
+                ],
+                "packageAddress" => [
+                  {
+                    "address" => "null",
+                    "attentionName" => "null",
+                    "name" => "null",
+                    "type" => "null"
+                  }
+                ],
+                "packageCount" => 2,
+                "paymentInformation" => [
+                  {
+                    "amount" => "null",
+                    "currency" => "null",
+                    "id" => "null",
+                    "paid" => "null",
+                    "paymentMethod" => "null",
+                    "type" => "null"
+                  }
+                ],
+                "referenceNumber" => [
+                  {
+                    "number" => "null",
+                    "type" => "null"
+                  }
+                ],
+                "service" => {
+                  "code" => "518",
+                  "description" => "UPS Ground",
+                  "levelCode" => "011"
+                },
+                "statusCode" => "string",
+                "statusDescription" => "string",
+                "suppressionIndicators" => "DETAIL",
+                "trackingNumber" => "string",
+                "weight" => {
+                  "unitOfMeasurement" => "string",
+                  "weight" => "string"
+                }
+              }
+            ],
+            "userRelation" => "MYCHOICE_HOME",
+            "warnings" => [
+              {
+                "code" => "string",
+                "message" => "string"
+              }
+            ]
+          }
+        ]
+      }
+    }
   end
 
   def track_ups_mi_not_found_response
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-    <TrackResponse>
-      <Response>
-        <TransactionReference>
-          <CustomerContext>4951bd50-6af6-4d92-abb4-c5025de11d42</CustomerContext>
-          <XpciVersion>1.0</XpciVersion>
-        </TransactionReference>
-        <ResponseStatusCode>0</ResponseStatusCode>
-        <ResponseStatusDescription>Failure</ResponseStatusDescription>
-        <Error>
-          <ErrorSeverity>Hard</ErrorSeverity>
-          <ErrorCode>155002</ErrorCode>
-          <ErrorDescription>Mail Innovations Tracking Information not found.</ErrorDescription>
-        </Error>
-      </Response>
-    </TrackResponse>"
+    {
+      "trackResponse" => {
+        "shipment" => [{
+          "inquiryNumber" => "1Z9912350341235622",
+          "warnings" => [{"code" => "TW0001", "message" => "Tracking Information Not Found"}]
+        }]
+      }
+    }
   end
 
   def track_ups_not_found_response
@@ -1373,343 +1559,6 @@ module MockResponses
   end
 
   def track_ups_surepost_response
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-    <TrackResponse>
-       <Response>
-          <TransactionReference>
-             <CustomerContext>320f2ecb-ff3e-4d5f-b93b-43becd9a046a</CustomerContext>
-             <XpciVersion>1.0</XpciVersion>
-          </TransactionReference>
-          <ResponseStatusCode>1</ResponseStatusCode>
-          <ResponseStatusDescription>Success</ResponseStatusDescription>
-       </Response>
-       <Shipment>
-          <Shipper>
-             <ShipperNumber>1161WA</ShipperNumber>
-             <Address>
-                <AddressLine1>S 507 2ND ST</AddressLine1>
-                <City>MILWAUKEE</City>
-                <StateProvinceCode>WI</StateProvinceCode>
-                <PostalCode>532041614</PostalCode>
-                <CountryCode>US</CountryCode>
-             </Address>
-          </Shipper>
-          <ShipTo>
-             <Address>
-                <City>LOS GATOS</City>
-                <StateProvinceCode>CA</StateProvinceCode>
-                <PostalCode>95032</PostalCode>
-                <CountryCode>US</CountryCode>
-             </Address>
-          </ShipTo>
-          <ShipmentWeight>
-             <UnitOfMeasurement>
-                <Code>LBS</Code>
-             </UnitOfMeasurement>
-             <Weight>4.80</Weight>
-          </ShipmentWeight>
-          <Service>
-             <Code>093</Code>
-             <Description>UPS SurePost</Description>
-          </Service>
-          <ReferenceNumber>
-             <Code>01</Code>
-             <Value>M681861103-1025</Value>
-          </ReferenceNumber>
-          <ShipmentIdentificationNumber>1Z1161WAYW93644228</ShipmentIdentificationNumber>
-          <PickupDate>20180522</PickupDate>
-          <Package>
-             <TrackingNumber>1Z1161WAYW93644228</TrackingNumber>
-             <DeliveryIndicator>N</DeliveryIndicator>
-             <RescheduledDeliveryDate>20180531</RescheduledDeliveryDate>
-             <PackageServiceOptions>
-                <USPSPICNumber>92612904851879541400755181</USPSPICNumber>
-             </PackageServiceOptions>
-             <Activity>
-                <ActivityLocation>
-                   <Address />
-                   <Description>Dock</Description>
-                </ActivityLocation>
-                <Status>
-                   <StatusType>
-                      <Code>I</Code>
-                      <Description>Received by the local post office</Description>
-                   </StatusType>
-                   <StatusCode>
-                      <Code>YH</Code>
-                   </StatusCode>
-                </Status>
-                <Date>20180530</Date>
-                <Time>034200</Time>
-             </Activity>
-             <Activity>
-                <ActivityLocation>
-                   <Address>
-                      <City>CAMPBELL</City>
-                      <PostalCode>95008</PostalCode>
-                      <CountryCode>US</CountryCode>
-                   </Address>
-                   <Code>AI</Code>
-                   <Description>Dock</Description>
-                   <SignedForByName>TO</SignedForByName>
-                </ActivityLocation>
-                <Status>
-                   <StatusType>
-                      <Code>D</Code>
-                      <Description>Package transferred to post office</Description>
-                   </StatusType>
-                   <StatusCode>
-                      <Code>LX</Code>
-                   </StatusCode>
-                </Status>
-                <Date>20180529</Date>
-                <Time>121524</Time>
-             </Activity>
-             <Activity>
-                <ActivityLocation>
-                   <Address>
-                      <City>San Jose</City>
-                      <StateProvinceCode>CA</StateProvinceCode>
-                      <CountryCode>US</CountryCode>
-                   </Address>
-                   <Description>Dock</Description>
-                </ActivityLocation>
-                <Status>
-                   <StatusType>
-                      <Code>I</Code>
-                      <Description>Destination Scan</Description>
-                   </StatusType>
-                   <StatusCode>
-                      <Code>YP</Code>
-                   </StatusCode>
-                </Status>
-                <Date>20180529</Date>
-                <Time>050247</Time>
-             </Activity>
-             <Activity>
-                <ActivityLocation>
-                   <Address>
-                      <City>San Jose</City>
-                      <StateProvinceCode>CA</StateProvinceCode>
-                      <CountryCode>US</CountryCode>
-                   </Address>
-                   <Description>Dock</Description>
-                </ActivityLocation>
-                <Status>
-                   <StatusType>
-                      <Code>I</Code>
-                      <Description>Destination Scan</Description>
-                   </StatusType>
-                   <StatusCode>
-                      <Code>DS</Code>
-                   </StatusCode>
-                </Status>
-                <Date>20180526</Date>
-                <Time>082028</Time>
-             </Activity>
-             <Activity>
-                <ActivityLocation>
-                   <Address>
-                      <City>San Jose</City>
-                      <StateProvinceCode>CA</StateProvinceCode>
-                      <CountryCode>US</CountryCode>
-                   </Address>
-                   <Description>Dock</Description>
-                </ActivityLocation>
-                <Status>
-                   <StatusType>
-                      <Code>X</Code>
-                      <Description>/ Package in transit and scheduled for UPS delivery attempt to recipient on next UPS business day.</Description>
-                   </StatusType>
-                   <StatusCode>
-                      <Code>6N</Code>
-                   </StatusCode>
-                </Status>
-                <Date>20180526</Date>
-                <Time>081930</Time>
-             </Activity>
-             <Activity>
-                <ActivityLocation>
-                   <Address>
-                      <City>San Jose</City>
-                      <StateProvinceCode>CA</StateProvinceCode>
-                      <CountryCode>US</CountryCode>
-                   </Address>
-                   <Description>Dock</Description>
-                </ActivityLocation>
-                <Status>
-                   <StatusType>
-                      <Code>I</Code>
-                      <Description>Arrival Scan</Description>
-                   </StatusType>
-                   <StatusCode>
-                      <Code>AR</Code>
-                   </StatusCode>
-                </Status>
-                <Date>20180526</Date>
-                <Time>055500</Time>
-             </Activity>
-             <Activity>
-                <ActivityLocation>
-                   <Address>
-                      <City>Oakland</City>
-                      <StateProvinceCode>CA</StateProvinceCode>
-                      <CountryCode>US</CountryCode>
-                   </Address>
-                   <Description>Dock</Description>
-                </ActivityLocation>
-                <Status>
-                   <StatusType>
-                      <Code>I</Code>
-                      <Description>Departure Scan</Description>
-                   </StatusType>
-                   <StatusCode>
-                      <Code>DP</Code>
-                   </StatusCode>
-                </Status>
-                <Date>20180526</Date>
-                <Time>050500</Time>
-             </Activity>
-             <Activity>
-                <ActivityLocation>
-                   <Address>
-                      <City>Oakland</City>
-                      <StateProvinceCode>CA</StateProvinceCode>
-                      <CountryCode>US</CountryCode>
-                   </Address>
-                   <Description>Dock</Description>
-                </ActivityLocation>
-                <Status>
-                   <StatusType>
-                      <Code>I</Code>
-                      <Description>Arrival Scan</Description>
-                   </StatusType>
-                   <StatusCode>
-                      <Code>AR</Code>
-                   </StatusCode>
-                </Status>
-                <Date>20180525</Date>
-                <Time>194300</Time>
-             </Activity>
-             <Activity>
-                <ActivityLocation>
-                   <Address>
-                      <City>San Pablo</City>
-                      <StateProvinceCode>CA</StateProvinceCode>
-                      <CountryCode>US</CountryCode>
-                   </Address>
-                   <Description>Dock</Description>
-                </ActivityLocation>
-                <Status>
-                   <StatusType>
-                      <Code>I</Code>
-                      <Description>Departure Scan</Description>
-                   </StatusType>
-                   <StatusCode>
-                      <Code>DP</Code>
-                   </StatusCode>
-                </Status>
-                <Date>20180525</Date>
-                <Time>190200</Time>
-             </Activity>
-             <Activity>
-                <ActivityLocation>
-                   <Address>
-                      <City>San Pablo</City>
-                      <StateProvinceCode>CA</StateProvinceCode>
-                      <CountryCode>US</CountryCode>
-                   </Address>
-                   <Description>Dock</Description>
-                </ActivityLocation>
-                <Status>
-                   <StatusType>
-                      <Code>I</Code>
-                      <Description>Arrival Scan</Description>
-                   </StatusType>
-                   <StatusCode>
-                      <Code>AR</Code>
-                   </StatusCode>
-                </Status>
-                <Date>20180525</Date>
-                <Time>163500</Time>
-             </Activity>
-             <Activity>
-                <ActivityLocation>
-                   <Address>
-                      <City>Oak Creek</City>
-                      <StateProvinceCode>WI</StateProvinceCode>
-                      <CountryCode>US</CountryCode>
-                   </Address>
-                   <Description>Dock</Description>
-                </ActivityLocation>
-                <Status>
-                   <StatusType>
-                      <Code>I</Code>
-                      <Description>Departure Scan</Description>
-                   </StatusType>
-                   <StatusCode>
-                      <Code>DP</Code>
-                   </StatusCode>
-                </Status>
-                <Date>20180523</Date>
-                <Time>074200</Time>
-             </Activity>
-             <Activity>
-                <ActivityLocation>
-                   <Address>
-                      <City>Oak Creek</City>
-                      <StateProvinceCode>WI</StateProvinceCode>
-                      <CountryCode>US</CountryCode>
-                   </Address>
-                   <Description>Dock</Description>
-                </ActivityLocation>
-                <Status>
-                   <StatusType>
-                      <Code>I</Code>
-                      <Description>Origin Scan</Description>
-                   </StatusType>
-                   <StatusCode>
-                      <Code>OR</Code>
-                   </StatusCode>
-                </Status>
-                <Date>20180522</Date>
-                <Time>220616</Time>
-             </Activity>
-             <Activity>
-                <ActivityLocation>
-                   <Address>
-                      <CountryCode>US</CountryCode>
-                   </Address>
-                   <Description>Dock</Description>
-                </ActivityLocation>
-                <Status>
-                   <StatusType>
-                      <Code>M</Code>
-                      <Description>Order Processed: Ready for UPS</Description>
-                   </StatusType>
-                   <StatusCode>
-                      <Code>MP</Code>
-                   </StatusCode>
-                </Status>
-                <Date>20180522</Date>
-                <Time>111527</Time>
-             </Activity>
-             <PackageWeight>
-                <UnitOfMeasurement>
-                   <Code>LBS</Code>
-                </UnitOfMeasurement>
-                <Weight>4.80</Weight>
-             </PackageWeight>
-             <ReferenceNumber>
-                <Code>01</Code>
-                <Value>M681861103-1025</Value>
-             </ReferenceNumber>
-             <Accessorial>
-                <Code>010</Code>
-                <Description>Hundredweight</Description>
-             </Accessorial>
-          </Package>
-       </Shipment>
-    </TrackResponse>"
+    track_ups_response
   end
 end

--- a/spec/mock_responses.rb
+++ b/spec/mock_responses.rb
@@ -629,6 +629,12 @@ module MockResponses
               {
                 "trackingNumber" => "1Z1202R66698804005",
                 "deliveryDate" => [],
+                "alternateTrackingNumber" => [
+                  {
+                    "number" => "123456",
+                    "type" => "Q"
+                  }
+                ],
                 "activity" => [
                   {
                     "location" => {
@@ -1415,17 +1421,19 @@ module MockResponses
                 "accessPointInformation" => {
                   "pickupByDate" => "string"
                 },
-                "activity" => [
-                  {
-                    "date" => "null",
-                    "gmtDate" => "null",
-                    "gmtOffset" => "null",
-                    "gmtTime" => "null",
-                    "location" => "null",
-                    "status" => "null",
-                    "time" => "null"
-                  }
-                ],
+                "activity" => [{
+                  "location" => {"slic"=>"9642"},
+                  "status" => {
+                    "type"=> "X",
+                    "description"=>"The package is at the clearing agency awaiting final release.",
+                    "statusCode"=>"092"
+                  },
+                  "date"=>"20240320",
+                  "time"=>"190838",
+                  "gmtDate"=>"20240320",
+                  "gmtOffset"=>"+08:00",
+                  "gmtTime"=>"11:08:38"
+                }],
                 "additionalAttributes" => [
                   "SENSOR_EVENT"
                 ],
@@ -1440,8 +1448,8 @@ module MockResponses
                 ],
                 "alternateTrackingNumber" => [
                   {
-                    "number" => "null",
-                    "type" => "null"
+                    "number" => "123456",
+                    "type" => "Q"
                   }
                 ],
                 "currentStatus" => {

--- a/spec/sample_config.yml
+++ b/spec/sample_config.yml
@@ -1,18 +1,21 @@
 Omniship:
   debug: false
   track_timeout: 5
-  
+
   UPS:
     username: '<%=ENV["UPS_USERNAME"]%>'
     password: '<%=ENV["UPS_PASSWORD"]%>'
     token: '<%=ENV["UPS_TOKEN"]%>'
+    client_id: '<%=ENV["UPS_CLIENT_ID"]%>'
+    client_secret: '<%=ENV["UPS_CLIENT_SECRET"]%>'
     test: false
+    source: Wantable, Inc.
 
   USPS:
     userid: '<%=ENV["USPS_USERID"]%>'
     password: '<%=ENV["USPS_PASSWORD"]%>'
     client_ip: 127.0.0.1
-    source_id: Wantable, Inc. 
+    source_id: Wantable, Inc.
 
     retailer:
       name: Wantable Inc
@@ -24,8 +27,8 @@ Omniship:
       zip5: 53204
     pdu:
       po_box: PO Box 514033
-      city: Milwaukee 
-      state: WI 
+      city: Milwaukee
+      state: WI
       zip5: 53203
 
   Landmark:

--- a/spec/ups/track_spec.rb
+++ b/spec/ups/track_spec.rb
@@ -20,29 +20,35 @@ describe "UPS::Track" do
     expect(trk.has_left?).to be true
   end
 
+  it 'mocked left shipment' do
+    trk = Omniship::UPS::Track::Response.new(track_ups_left_not_arrived)
+
+    expect(trk.has_arrived?).to be false
+    expect(trk.has_left?).to be true
+  end
+
   it 'timstamp parsing' do
     expect(Omniship::UPS.parse_timestamp("20170117", "211600")).to eq(Time.parse("2017-01-17 21:16"))
   end
 
-  it 'test xml parsing' do
-    trk = Omniship::UPS::Track::Response.new(Nokogiri::XML::Document.parse(track_ups_response))
+  it 'test json parsing' do
+    trk = Omniship::UPS::Track::Response.new(track_ups_response)
     expect(trk.has_left?).to eq true
-    expect(trk.has_arrived?).to eq true
+    expect(trk.has_arrived?).to eq false
     package = trk.shipment.packages.first
     expect(package.tracking_number).to_not be_nil
     expect(trk.shipment.scheduled_delivery).to be_nil
     activity = package.activity.first
     expect(activity.code).to_not be_nil
     expect(activity.status).to_not be_nil
-    expect(activity.address.to_s).to eq("SANTA CLARA, CA 95053 US")
     expect(activity.timestamp).to_not be_nil
 
     alternate_tracking = package.alternate_tracking
     expect(alternate_tracking).to be_nil
   end
 
-  it 'text xml parsing of mail innovations' do
-    trk = Omniship::UPS::Track::Response.new(Nokogiri::XML::Document.parse(track_ups_mi_response))
+  it 'text json parsing of mail innovations' do
+    trk = Omniship::UPS::Track::Response.new(track_ups_mi_response)
     expect(trk.has_left?).to eq true
     expect(trk.has_arrived?).to eq true
     package = trk.shipment.packages.first
@@ -53,8 +59,8 @@ describe "UPS::Track" do
     expect(alternate_tracking.type).to eq(Omniship::UPS::Track::AlternateTracking::POSTAL_SERVICE_TRACKING_ID)
     expect(alternate_tracking.value).to_not be_nil
   end
-  it 'test xml parsing of surepost' do
-    trk = Omniship::UPS::Track::Response.new(Nokogiri::XML::Document.parse(track_ups_surepost_response))
+  it 'test json parsing of surepost' do
+    trk = Omniship::UPS::Track::Response.new(track_ups_surepost_response)
     expect(trk.has_left?).to eq true
     expect(trk.has_arrived?).to eq false # will never get to true because this package doesn't know the result of the alternate_tracking package
     package = trk.shipment.packages.first
@@ -67,7 +73,7 @@ describe "UPS::Track" do
   end
 
   it 'test parsing not found' do
-    error = Omniship::UPS::Track::Error.new(404, track_ups_not_found_response)
+    error = Omniship::UPS::Track::Error.new(404, track_ups_not_found_response.dig('trackResponse', 'shipment').first['warnings'])
     expect(error.code).to eq(Omniship::TrackError::NOT_FOUND)
   end
 end

--- a/spec/ups/track_spec.rb
+++ b/spec/ups/track_spec.rb
@@ -42,15 +42,12 @@ describe "UPS::Track" do
     expect(activity.code).to_not be_nil
     expect(activity.status).to_not be_nil
     expect(activity.timestamp).to_not be_nil
-
-    alternate_tracking = package.alternate_tracking
-    expect(alternate_tracking).to be_nil
   end
 
   it 'text json parsing of mail innovations' do
     trk = Omniship::UPS::Track::Response.new(track_ups_mi_response)
-    expect(trk.has_left?).to eq true
-    expect(trk.has_arrived?).to eq true
+    expect(trk.has_left?).to eq false
+    expect(trk.has_arrived?).to eq false
     package = trk.shipment.packages.first
     expect(package.tracking_number).to_not be_nil
 

--- a/spec/ups/track_spec.rb
+++ b/spec/ups/track_spec.rb
@@ -67,7 +67,7 @@ describe "UPS::Track" do
   end
 
   it 'test xml parsing not found' do
-    error = Omniship::UPS::Track::Error.new(Nokogiri::XML::Document.parse(track_ups_not_found_response))
+    error = Omniship::UPS::Track::Error.new(404, Nokogiri::XML::Document.parse(track_ups_not_found_response))
     expect(error.code).to eq(Omniship::TrackError::NOT_FOUND)
   end
 end

--- a/spec/ups/track_spec.rb
+++ b/spec/ups/track_spec.rb
@@ -66,8 +66,8 @@ describe "UPS::Track" do
     expect(alternate_tracking.value).to_not be_nil
   end
 
-  it 'test xml parsing not found' do
-    error = Omniship::UPS::Track::Error.new(404, Nokogiri::XML::Document.parse(track_ups_not_found_response))
+  it 'test parsing not found' do
+    error = Omniship::UPS::Track::Error.new(404, track_ups_not_found_response)
     expect(error.code).to eq(Omniship::TrackError::NOT_FOUND)
   end
 end

--- a/spec/upsmi/track_spec.rb
+++ b/spec/upsmi/track_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe "UPSMI::Track" do
-  it 'invalid tracking' do 
+  it 'invalid tracking' do
     expect { Omniship::UPSMI.track(UPSMI_TEST_NUMBER)  }.to_not raise_error(Omniship::TrackError)
     expect { Omniship::UPSMI.track(UPS_INVALID_TEST_NUMBER)  }.to raise_error(Omniship::TrackError)
   end
 
-  it 'test xml parsing' do 
-    trk = Omniship::UPS::Track::Response.new(Nokogiri::XML::Document.parse(track_ups_response))
+  it 'test xml parsing' do
+    trk = Omniship::UPS::Track::Response.new(track_ups_response)
     expect(trk.has_left?).to eq true
     expect(trk.has_arrived?).to eq true
     package = trk.shipment.packages.first
@@ -19,9 +19,9 @@ describe "UPSMI::Track" do
     expect(activity.address.to_s).to eq("SANTA CLARA, CA 95053 US")
     expect(activity.timestamp).to_not be_nil
   end
-  
-  it 'test xml parsing not found' do 
-    error = Omniship::UPS::Track::Error.new(Nokogiri::XML::Document.parse(track_ups_mi_not_found_response))
+
+  it 'test xml parsing not found' do
+    error = Omniship::UPS::Track::Error.new(404, track_ups_mi_not_found_response)
     expect(error.code).to eq(Omniship::TrackError::NOT_FOUND)
   end
 

--- a/spec/upsmi/track_spec.rb
+++ b/spec/upsmi/track_spec.rb
@@ -6,22 +6,21 @@ describe "UPSMI::Track" do
     expect { Omniship::UPSMI.track(UPS_INVALID_TEST_NUMBER)  }.to raise_error(Omniship::TrackError)
   end
 
-  it 'test xml parsing' do
+  it 'test json parsing' do
     trk = Omniship::UPS::Track::Response.new(track_ups_response)
     expect(trk.has_left?).to eq true
-    expect(trk.has_arrived?).to eq true
+    expect(trk.has_arrived?).to eq false
     package = trk.shipment.packages.first
     expect(package.tracking_number).to_not be_nil
     expect(trk.shipment.scheduled_delivery).to be_nil
     activity = package.activity.first
     expect(activity.code).to_not be_nil
     expect(activity.status).to_not be_nil
-    expect(activity.address.to_s).to eq("SANTA CLARA, CA 95053 US")
     expect(activity.timestamp).to_not be_nil
   end
 
-  it 'test xml parsing not found' do
-    error = Omniship::UPS::Track::Error.new(404, track_ups_mi_not_found_response)
+  it 'test json parsing not found' do
+    error = Omniship::UPS::Track::Error.new(404, track_ups_mi_not_found_response.dig('trackResponse', 'shipment').first['warnings'])
     expect(error.code).to eq(Omniship::TrackError::NOT_FOUND)
   end
 


### PR DESCRIPTION
Surprisingly UPS has their API not behind an account-wall
The 2 endpoints are 

https://developer.ups.com/api/reference?loc=en_US#tag/OAuthAuthCode_other
https://developer.ups.com/api/reference?loc=en_US#tag/Tracking_other

Nothing too crazy. Keep the bearer token for as long as it says we can - 5 seconds. Then just do a normal request that returns JSON! No more XML parsing for UPS!


