### PR TITLE
WOEM 13643 | Pitney Bowes Tracking

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniship (0.3.14)
+    omniship (0.3.15)
       curb
       json
       nokogiri (= 1.16)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniship (0.3.15)
+    omniship (0.4.0)
       curb
       json
       nokogiri (= 1.16)

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ Omniship.tracking_url('1z3050790327433970')
 
 TODO
 ------
+- Add rubocop or some code standardization
 - Convert tests to use [webmock](https://github.com/bblimke/webmock) or similar strategy instead of calling the api's.
   - Unskip Landmark and Newgistics tests once they are passing with valid credentials. Search for "I no longer have valid test api credentials"
 - Fix time zone issue with Newgistics.parse_timestamp

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Omniship::DHLGM.username = 'johndoe'
 Omniship::DHLGM.password = '1234567890'
 Omniship::DHLGM.mailer_id = '1234567890' # this is required to detect the shipper type, since USPS and DHL are otherwise indistinguisiblle
 
+Omniship::PitneyBowes.api_key = 'XXXX'
+Omniship::PitneyBowes.api_secret = 'YYYY'
+Omniship::PitneyBowes.test = true/false
+
 Omniship.debug = true # with this enabled all xml request's and responses will be outputed to the log
 
 Omniship.track_timeout = 5 # timeout for a tracking request in seconds. Only implemented on UPS, USPS, DHLGM. Default = 10 seconds
@@ -105,6 +109,11 @@ Omniship:
   DHLGM:
     username: johndoe
     password: 1234567890
+
+  PitneyBowes:
+    api_key: YYYY
+    api_secret: XXXX
+    test: false
 ```
 
 
@@ -282,6 +291,29 @@ trk.shipment.class
 
 trk.shipment.scheduled_delivery - not supported by DHL Global Mail
 # => nil
+
+trk.shipment.packages.first.has_left?
+# => true / false
+
+trk.shipment.packages.first.has_arrived?
+# => true / false
+```
+
+PitneyBowes
+---------------
+
+Track
+
+```ruby
+trk = Omniship::PitneyBowes.track('12345')
+trk.class
+# => Omniship::PitneyBowes::Track::Response
+
+trk.shipment.class
+# => Omniship::PitneyBowes::Track::Shipment
+
+trk.shipment.scheduled_delivery
+# => nil / date
 
 trk.shipment.packages.first.has_left?
 # => true / false

--- a/lib/omniship.rb
+++ b/lib/omniship.rb
@@ -100,7 +100,7 @@ module Omniship
       if pitney_bowes = omniship['PitneyBowes']
         PitneyBowes.api_key = pitney_bowes['api_key']
         PitneyBowes.api_secret = pitney_bowes['api_secret']
-        PitneyBowes.test = pitney_bowes['test'].to_s
+        PitneyBowes.test = pitney_bowes['test']
       end
     end
     nil

--- a/lib/omniship.rb
+++ b/lib/omniship.rb
@@ -22,10 +22,11 @@ require 'omniship/dhlgm'
 require 'omniship/dhl'
 require 'omniship/fed_ex'
 require 'omniship/newgistics'
+require 'omniship/pitney_bowes'
 
 
 module Omniship
-  PROVIDERS = [UPSMI, UPS, Landmark, FedEx, DHLGM, DHL, USPS, Newgistics]
+  PROVIDERS = [UPSMI, UPS, Landmark, FedEx, DHLGM, DHL, USPS, Newgistics, PitneyBowes]
   class << self
     attr_accessor :debug, :track_timeout
   end
@@ -94,6 +95,12 @@ module Omniship
         Newgistics.merchant_id = newgistics['merchant_id']
         Newgistics.api_key = newgistics['api_key']
         Newgistics.test = newgistics['test'].to_s
+      end
+
+      if pitney_bowes = omniship['PitneyBowes']
+        PitneyBowes.api_key = pitney_bowes['api_key']
+        PitneyBowes.api_secret = pitney_bowes['api_secret']
+        PitneyBowes.test = pitney_bowes['test'].to_s
       end
     end
     nil

--- a/lib/omniship/pitney_bowes.rb
+++ b/lib/omniship/pitney_bowes.rb
@@ -6,8 +6,8 @@ module Omniship
     TRACKING_REGEX = [/^920[0-9]{23}$/]
     TRACKING_URL = "https://trackpb.shipment.co/track/"
     DATE_FORMAT = "%Y-%m-%d"
-    TIMESTAMP_FORMAT = "%Y-%m-%d %H-%M-%S"
-    TIMESTAMP_FORMAT_WITH_OFFSET = "%Y-%m-%d %H-%M-%S %z"
+    TIMESTAMP_FORMAT = "#{DATE_FORMAT} %H:%M:%S"
+    TIMESTAMP_FORMAT_WITH_OFFSET = "#{TIMESTAMP_FORMAT} %z"
 
     class << self
       attr_accessor :api_key, :api_secret, :test

--- a/lib/omniship/pitney_bowes.rb
+++ b/lib/omniship/pitney_bowes.rb
@@ -3,7 +3,7 @@ require 'omniship/pitney_bowes/track'
 module Omniship
   module PitneyBowes
     LABEL = 'PitneyBowes'.freeze
-    TRACKING_REGEX = [/^920[0-9]{23}$/
+    TRACKING_REGEX = [/^920[0-9]{23}$/]
     TRACKING_URL = "https://trackpb.shipment.co/track/"
     DATE_FORMAT = "%Y-%m-%d"
     TIMESTAMP_FORMAT = "%Y-%m-%d %H-%M-%S"

--- a/lib/omniship/pitney_bowes.rb
+++ b/lib/omniship/pitney_bowes.rb
@@ -1,0 +1,42 @@
+require 'omniship/pitney_bowes/track'
+
+module Omniship
+  module PitneyBowes
+    LABEL = 'PitneyBowes'.freeze
+    TRACKING_REGEX = [/^920[0-9]{23}$/
+    TRACKING_URL = "https://trackpb.shipment.co/track/"
+    DATE_FORMAT = "%Y-%m-%d"
+    TIMESTAMP_FORMAT = "%Y-%m-%d %H-%M-%S"
+    TIMESTAMP_FORMAT_WITH_OFFSET = "%Y-%m-%d %H-%M-%S %z"
+
+    class << self
+      attr_accessor :api_key, :api_secret, :test
+    end
+
+    def self.tracking_test?(tracking)
+      TRACKING_REGEX.any? { |regex| tracking =~ regex}
+    end
+
+    def self.track(id)
+      Track::Request.track(id)
+    end
+
+    def self.tracking_url(number)
+      TRACKING_URL + number
+    end
+
+    # <Date>YYYY-MM-DD</Date>
+    # <Time>HH:MM:SS </Time>
+    # <offset>±hh:mm</offset>
+    def self.parse_timestamp(date, time = nil, offset = nil)
+      return if date.nil? || date.empty?
+      if time.nil? || time.empty?
+        Time.strptime("#{date}", DATE_FORMAT)
+      elsif offset.nil? || offset.empty?
+        Time.strptime("#{date} #{time}", TIMESTAMP_FORMAT)
+      else
+        Time.strptime("#{date} #{time} #{offset}", TIMESTAMP_FORMAT_WITH_OFFSET)
+      end
+    end
+  end
+end

--- a/lib/omniship/pitney_bowes/track.rb
+++ b/lib/omniship/pitney_bowes/track.rb
@@ -1,4 +1,3 @@
-require 'omniship/pitney_bowes/track/alternate_tracking'
 require 'omniship/pitney_bowes/track/activity'
 require 'omniship/pitney_bowes/track/address'
 require 'omniship/pitney_bowes/track/package'

--- a/lib/omniship/pitney_bowes/track.rb
+++ b/lib/omniship/pitney_bowes/track.rb
@@ -1,0 +1,8 @@
+require 'omniship/pitney_bowes/track/alternate_tracking'
+require 'omniship/pitney_bowes/track/activity'
+require 'omniship/pitney_bowes/track/address'
+require 'omniship/pitney_bowes/track/package'
+require 'omniship/pitney_bowes/track/shipment'
+require 'omniship/pitney_bowes/track/error'
+require 'omniship/pitney_bowes/track/request'
+require 'omniship/pitney_bowes/track/response'

--- a/lib/omniship/pitney_bowes/track/activity.rb
+++ b/lib/omniship/pitney_bowes/track/activity.rb
@@ -1,0 +1,27 @@
+module Omniship
+  module PitneyBowes
+    module Track
+      class Activity < Omniship::Base
+        def address
+          @address ||= Address.new(root.slice('eventCity', 'eventStateOrProvince', 'postalCode', 'country'))
+        end
+
+        def status
+          root['packageStatus']
+        end
+
+        def code
+          root['standardizedEventCode']
+        end
+
+        def timestamp
+          date, time, offset = root.values_at('eventDate', 'eventTime', 'eventTimeOffset')
+
+          return if date.nil? || date.empty?
+
+          Omniship::PitneyBowes.parse_timestamp(root['date'], root['time'])
+        end
+      end
+    end
+  end
+end

--- a/lib/omniship/pitney_bowes/track/activity.rb
+++ b/lib/omniship/pitney_bowes/track/activity.rb
@@ -19,7 +19,7 @@ module Omniship
 
           return if date.nil? || date.empty?
 
-          Omniship::PitneyBowes.parse_timestamp(root['date'], root['time'])
+          Omniship::PitneyBowes.parse_timestamp(date, time, offset)
         end
       end
     end

--- a/lib/omniship/pitney_bowes/track/address.rb
+++ b/lib/omniship/pitney_bowes/track/address.rb
@@ -1,0 +1,27 @@
+module Omniship
+  module PitneyBowes
+    module Track
+      class Address < Omniship::Base
+        def city
+          root['eventCity']
+        end
+
+        def state
+          root['eventStateOrProvince']
+        end
+
+        def country
+          root['country']
+        end
+
+        def postal_code
+          root['postalCode']
+        end
+
+        def to_s
+          "#{city}, #{state} #{postal_code} #{country}"
+        end
+      end
+    end
+  end
+end

--- a/lib/omniship/pitney_bowes/track/error.rb
+++ b/lib/omniship/pitney_bowes/track/error.rb
@@ -1,0 +1,14 @@
+module Omniship
+  module PitneyBowes
+    module Track
+      class Error < TrackError
+        # errors are an array of { code: 'string', message: 'string' }
+        def initialize(code, errors)
+          self.code = NOT_FOUND if code == 404
+
+          super(errors.map { |e| e['message'] }.join(', '))
+        end
+      end
+    end
+  end
+end

--- a/lib/omniship/pitney_bowes/track/package.rb
+++ b/lib/omniship/pitney_bowes/track/package.rb
@@ -1,0 +1,35 @@
+module Omniship
+  module PitneyBowes
+    module Track
+      class Package < Omniship::Base
+        # https://www.docs.pitneybowes.com/document/standardized-tracking-event-code-list
+        DELIVERED = 'Delivered'.freeze
+        LEFT_STATUSES = %w[InTransit OutForDelivery PickedUp].freeze
+
+        def tracking_number
+          root['trackingNumber']
+        end
+
+        def activity
+          @activity ||= root['scanDetailsList'].map do |act|
+            Activity.new(act)
+          end
+        end
+
+        def has_left?
+          activity.any? { |activity| LEFT_STATUSES.include?(activity.status) }
+        end
+
+        def has_arrived?
+          activity.any? { |activity| activity.status == DELIVERED }
+        end
+
+        # handled in shipment.rb
+        def delivery_dates; end
+
+        # not supported yet
+        def alternate_tracking; end
+      end
+    end
+  end
+end

--- a/lib/omniship/pitney_bowes/track/request.rb
+++ b/lib/omniship/pitney_bowes/track/request.rb
@@ -10,7 +10,7 @@ module Omniship
         TOKEN_PATH = 'oauth/token'
         TRACK_PATH = 'shippingservices/v1/tracking/'
 
-        def self.endpoint
+        def self.base_url
           if PitneyBowes.test == true
             TEST_URL
           else
@@ -32,11 +32,6 @@ module Omniship
             raise Error.new(raw_response.code, response.dig('response', 'errors'))
           end
 
-          # # Sometimes the tracking number is technically valid but doesn't actually exist. Still want to raise not found
-          # if raw_response.code == 200 && response.dig('trackResponse', 'shipment')&.first&.key?('warnings')
-          #   raise Error.new(404, response.dig('trackResponse', 'shipment').first['warnings'])
-          # end
-
           Response.new(response)
         end
 
@@ -49,7 +44,7 @@ module Omniship
 
           raw_response = RestClient::Request.execute(
             method: :post,
-            url: endpoint + TOKEN_PATH,
+            url: base_url + TOKEN_PATH,
             timeout: 20,
             headers: {
               content_type: 'application/x-www-form-urlencoded',
@@ -81,7 +76,7 @@ module Omniship
         end
 
         def self.get_response(tracking_number)
-          tracking_url = endpoint + TRACK_PATH + tracking_number
+          tracking_url = base_url + TRACK_PATH + tracking_number
 
           puts tracking_url if Omniship.debug
 

--- a/lib/omniship/pitney_bowes/track/request.rb
+++ b/lib/omniship/pitney_bowes/track/request.rb
@@ -90,17 +90,17 @@ module Omniship
             headers: {
               'Authorization' => "Bearer #{oauth_client_credentials}",
               accept: :json,
-              'Content-Type' => 'application/json; charset=UTF-8'
+              'Content-Type' => 'application/json; charset=UTF-8',
+              params: {
+                carrier: 'PBCS',
+                packageIdentifierType: 'TrackingNumber'
+              }
             },
-            url: "#{tracking_url}?carrier=PBCS&packageIdentifierType=TrackingNumber",
+            url: tracking_url,
             content_type: 'application/json',
             accept: 'application/json',
             timeout: Omniship.track_timeout,
-            open_timeout: Omniship.track_timeout# ,
-            # params: {
-            #   carrier: 'PBCS',
-            #   packageIdentifierType: 'TrackingNumber'
-            # }
+            open_timeout: Omniship.track_timeout
           )
         rescue RestClient::Unauthorized => e
           e.response

--- a/lib/omniship/pitney_bowes/track/request.rb
+++ b/lib/omniship/pitney_bowes/track/request.rb
@@ -92,15 +92,15 @@ module Omniship
               accept: :json,
               'Content-Type' => 'application/json; charset=UTF-8'
             },
-            url: tracking_url,
+            url: "#{tracking_url}?carrier=PBCS&packageIdentifierType=TrackingNumber",
             content_type: 'application/json',
             accept: 'application/json',
             timeout: Omniship.track_timeout,
-            open_timeout: Omniship.track_timeout,
-            params: {
-              carrier: 'PBCS',
-              packageIdentifierType: 'TrackingNumber'
-            }
+            open_timeout: Omniship.track_timeout# ,
+            # params: {
+            #   carrier: 'PBCS',
+            #   packageIdentifierType: 'TrackingNumber'
+            # }
           )
         rescue RestClient::Unauthorized => e
           e.response

--- a/lib/omniship/pitney_bowes/track/request.rb
+++ b/lib/omniship/pitney_bowes/track/request.rb
@@ -88,7 +88,7 @@ module Omniship
           RestClient::Request.execute(
             method: :get,
             headers: {
-              'Authorization' => "Bearer #{oauth_client_credentials}"
+              'Authorization' => "Bearer #{oauth_client_credentials}",
               accept: :json,
               'Content-Type' => 'application/json; charset=UTF-8'
             },

--- a/lib/omniship/pitney_bowes/track/request.rb
+++ b/lib/omniship/pitney_bowes/track/request.rb
@@ -38,7 +38,7 @@ module Omniship
         private
 
         def self.oauth_client_credentials
-          if @oauth_client_credentials && @oauth_client_credentials[:expires_at] > Time.zone.now.to_i
+          if @oauth_client_credentials && @oauth_client_credentials[:expires_at] > Time.now.to_i
             return @oauth_client_credentials[:access_token]
           end
 

--- a/lib/omniship/pitney_bowes/track/request.rb
+++ b/lib/omniship/pitney_bowes/track/request.rb
@@ -1,0 +1,111 @@
+module Omniship
+  module PitneyBowes
+    module Track
+      class Request
+        ERROR_RESPONSE = 0
+
+        TEST_URL = 'https://shipping-api-sandbox.pitneybowes.com/'
+        LIVE_URL = 'https://shipping-api.pitneybowes.com/'
+
+        TOKEN_PATH = 'oauth/token'
+        TRACK_PATH = 'shippingservices/v1/tracking/{identifier}' # ?packageIdentifierType=TrackingNumber
+
+        def self.endpoint
+          if PitneyBowes.test == true
+            TEST_URL
+          else
+            LIVE_URL
+          end
+        end
+
+        def self.track(tracking_number)
+          raw_response = get_response(tracking_number)
+
+          response = JSON.parse(raw_response.body)
+
+          if Omniship.debug
+            puts raw_response.code
+            puts response.inspect
+          end
+
+          unless response.dig('response', 'errors').nil?
+            raise Error.new(raw_response.code, response.dig('response', 'errors'))
+          end
+
+          # # Sometimes the tracking number is technically valid but doesn't actually exist. Still want to raise not found
+          # if raw_response.code == 200 && response.dig('trackResponse', 'shipment')&.first&.key?('warnings')
+          #   raise Error.new(404, response.dig('trackResponse', 'shipment').first['warnings'])
+          # end
+
+          Response.new(response)
+        end
+
+        private
+
+        def self.oauth_client_credentials
+          if @oauth_client_credentials && @oauth_client_credentials[:expires_at] > Time.zone.now.to_i
+            return @oauth_client_credentials[:access_token]
+          end
+
+          raw_response = RestClient::Request.execute(
+            method: :post,
+            url: endpoint + TOKEN_PATH,
+            timeout: 20,
+            headers: {
+              content_type: 'application/x-www-form-urlencoded',
+              Authorization: "Basic <#{base64_oauth_creds}>"
+            },
+            payload: {
+              grant_type: 'client_credentials'
+            },
+            timeout: Omniship.track_timeout,
+            open_timeout: Omniship.track_timeout
+          )
+
+          puts raw_response if Omniship.debug
+
+          response = JSON.parse(raw_response.body)
+
+          raise 'PitneyBowes TOKEN REQUEST NOT APPROVED' if raw_response.code != 200
+
+          @oauth_client_credentials = {
+            access_token: response.fetch('access_token'),
+            expires_at: Time.now.to_i + response.fetch('expiresIn').to_i - 5 # request new token 5 seconds before expiration
+          }
+
+          @oauth_client_credentials[:access_token]
+        end
+
+        def self.base64_oauth_creds
+          Base64.strict_encode64("#{PitneyBowes.api_key}:#{PitneyBowes.api_secret}")
+        end
+
+        def self.get_response(tracking_number)
+          tracking_url = endpoint + TRACK_PATH + tracking_number
+
+          puts tracking_url if Omniship.debug
+
+          RestClient::Request.execute(
+            method: :get,
+            headers: {
+              'Authorization' => "Bearer #{oauth_client_credentials}"
+              accept: :json,
+              'Content-Type' => 'application/json; charset=UTF-8'
+            },
+            url: tracking_url,
+            content_type: 'application/json',
+            accept: 'application/json',
+            timeout: Omniship.track_timeout,
+            open_timeout: Omniship.track_timeout,
+            params: {
+              carrier: 'PBCS',
+              packageIdentifierType: 'TrackingNumber'
+            }
+          )
+        rescue RestClient::Unauthorized => e
+          e.response
+        end
+      end
+    end
+  end
+end

--- a/lib/omniship/pitney_bowes/track/request.rb
+++ b/lib/omniship/pitney_bowes/track/request.rb
@@ -8,7 +8,7 @@ module Omniship
         LIVE_URL = 'https://shipping-api.pitneybowes.com/'
 
         TOKEN_PATH = 'oauth/token'
-        TRACK_PATH = 'shippingservices/v1/tracking/{identifier}' # ?packageIdentifierType=TrackingNumber
+        TRACK_PATH = 'shippingservices/v1/tracking/'
 
         def self.endpoint
           if PitneyBowes.test == true

--- a/lib/omniship/pitney_bowes/track/request.rb
+++ b/lib/omniship/pitney_bowes/track/request.rb
@@ -45,7 +45,6 @@ module Omniship
           raw_response = RestClient::Request.execute(
             method: :post,
             url: base_url + TOKEN_PATH,
-            timeout: 20,
             headers: {
               content_type: 'application/x-www-form-urlencoded',
               Authorization: "Basic <#{base64_oauth_creds}>"

--- a/lib/omniship/pitney_bowes/track/response.rb
+++ b/lib/omniship/pitney_bowes/track/response.rb
@@ -1,0 +1,20 @@
+module Omniship
+  module PitneyBowes
+    module Track
+      class Response < Omniship::Base
+
+        def shipment
+          @shipment ||= Track::Shipment.new(root)
+        end
+
+        def has_left?
+          !shipment.packages.empty? && shipment.packages.all?(&:has_left?)
+        end
+
+        def has_arrived?
+          !shipment.packages.empty? && shipment.packages.all?(&:has_arrived?)
+        end
+      end
+    end
+  end
+end

--- a/lib/omniship/pitney_bowes/track/shipment.rb
+++ b/lib/omniship/pitney_bowes/track/shipment.rb
@@ -1,0 +1,21 @@
+module Omniship
+  module PitneyBowes
+    module Track
+      class Shipment < Omniship::Base
+        def packages
+          @packages ||= [Package.new(root)]
+        end
+
+        def scheduled_delivery
+          return if root['estimatedDeliveryDate'].nil? || root['estimatedDeliveryDate'].empty?
+
+          date = root['estimatedDeliveryDate']
+          time = root['estimatedDeliveryTime']
+          time = root['estimatedDeliveryTimeOffset']
+
+          Omniship::PitneyBowes.parse_timestamp(date, time, offset)
+        end
+      end
+    end
+  end
+end

--- a/lib/omniship/version.rb
+++ b/lib/omniship/version.rb
@@ -1,3 +1,3 @@
 module Omniship
-  VERSION = '0.3.14'
+  VERSION = '0.3.15'
 end

--- a/lib/omniship/version.rb
+++ b/lib/omniship/version.rb
@@ -1,3 +1,3 @@
 module Omniship
-  VERSION = '0.3.15'
+  VERSION = '0.4.0'
 end

--- a/spec/mock_responses.rb
+++ b/spec/mock_responses.rb
@@ -1569,4 +1569,43 @@ module MockResponses
   def track_ups_surepost_response
     track_ups_response
   end
+
+  def track_pitney_bowes_response
+    {
+      'packageCount' => 1,
+      'reattemptDate' => nil,
+      'reattemptTime' => nil,
+      'signedBy' => nil,
+      'senderAddress' => { 'name' => nil, 'address1' => nil, 'address2' => nil, 'address3' => nil, 'city' => nil, 'stateOrProvince' => nil, 'postalCode' => nil, 'country' => nil },
+      'requestedIdentifier' => '92023903406069000000000285',
+      'clientId' => nil, 'trackingNumber' => '4205690192023903406069000000000285',
+      'referenceNumber' => 'W435706480',
+      'smartLabelBarcode' => '725109850102377001010000000000W435706480N',
+      'carrier' => 'PBCS',
+      'serviceName' => 'Parcel Return Service',
+      'serviceCode' => 'RP',
+      'estimatedDeliveryDate' => nil,
+      'estimatedDeliveryTime' => nil,
+      'estimatedDeliveryTimeOffset' => nil,
+      'weight' => '4.06',
+      'weightUOM' => 'LBS',
+      'dimension' => nil,
+      'deliveryDate' => nil,
+      'deliveryTime' => nil,
+      'deliveryTimeOffset' => nil,
+      'deliveryProofUrl' => nil,
+      'shipDate' => nil, 'shipTime' => nil, 'shipTimeOffset' => nil,
+      'destinationAddress' => { 'name' => nil, 'address1' => nil, 'address2' => nil, 'address3' => nil, 'city' => nil, 'stateOrProvince' => nil, 'country' => nil, 'postalCode' => nil },
+      'deliveryLocation' => nil,
+      'deliveryLocationDescription' => nil,
+      'scanDetailsList' => [
+        { 'standardizedEventCode' => 'LC', 'standardizedEventDescription' => 'Label created', 'l1Code' => 'LC', 'l1Description' => 'Label Created', 'eventDate' => '2024-07-24', 'eventTime' => '12:20:26', 'eventTimeOffset' => '-07:00', 'trackingUrl' => nil, 'latitude' => nil, 'longitude' => nil, 'locationUnit' => nil, 'eventLeg' => 'FML', 'eventType' => 'RTN', 'authorizedAgent' => nil, 'scanType' => 'LC', 'scanDescription' => 'Label created', 'packageStatus' => 'Manifest', 'l2Description' => nil, 'eventCity' => 'Olympia', 'eventStateOrProvince' => 'WA', 'postalCode' => '98501-6202', 'country' => 'US' }
+      ],
+      'currentStatus' => { 'standardizedEventCode' => 'LC', 'standardizedEventDescription' => 'Label created', 'l1Code' => 'LC', 'l1Description' => 'Label Created', 'eventDate' => '2024-07-24', 'eventTime' => '12:20:26', 'eventTimeOffset' => '-07:00', 'trackingUrl' => nil, 'latitude' => nil, 'longitude' => nil, 'locationUnit' => nil, 'eventLeg' => 'FML', 'eventType' => 'RTN', 'authorizedAgent' => nil, 'packageStatus' => 'Manifest', 'scanType' => 'LC', 'scanDescription' => 'Label created', 'l2Description' => nil, 'eventCity' => 'Olympia', 'eventStateOrProvince' => 'WA', 'postalCode' => '98501-6202', 'country' => 'US' },
+      'status' => 'Manifest',
+      'updatedDate' => '2024-07-24',
+      'updatedTime' => '12:20:26',
+      'lastPackageStatusLocation' => 'Olympia,WA,98501-6202'
+    }
+  end
 end

--- a/spec/pitney_bowes/track_spec.rb
+++ b/spec/pitney_bowes/track_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe "PitneyBowes::Track" do
+  it 'test json parsing' do
+    trk = Omniship::PitneyBowes::Track::Response.new(track_pitney_bowes_response)
+    expect(trk.has_left?).to eq false
+    expect(trk.has_arrived?).to eq false
+    package = trk.shipment.packages.first
+    expect(package.tracking_number).to_not be_nil
+    expect(trk.shipment.scheduled_delivery).to be_nil
+    activity = package.activity.first
+    expect(activity.code).to_not be_nil
+    expect(activity.status).to_not be_nil
+    expect(activity.timestamp).to_not be_nil
+  end
+end

--- a/spec/sample_config.yml
+++ b/spec/sample_config.yml
@@ -45,3 +45,8 @@ Omniship:
   Newgistics:
     merchant_id: '<%=ENV["NEWGISTICS_MERCHANT_ID"]%>'
     api_key: '<%=ENV["NEWGISTICS_API_KEY"]%>'
+
+  PitneyBowes:
+    api_key: '<%=ENV["PITNEY_BOWES_API_KEY"]%>'
+    api_secret: '<%=ENV["PITNEY_BOWES_API_SECRET"]%>'
+    test: true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,7 @@ RSpec.configure do |config|
                                           # from https://mercury.landmarkglobal.com/clients/KnowledgeBase/index.php?topic_name=Track+API+Request&hash=539fd53b59e3bb12d203f45a912eeaf2
     Omniship::UPS.test = true
     Omniship::USPS.test = true
+    Omniship::PitneyBowes.test = true
     Omniship::Newgistics.test = true
   }
 end


### PR DESCRIPTION
This adds PB package tracking
https://docs.shippingapi.pitneybowes.com/api/get-tracking.html

Technically could get mostly away with doing USPS but their tracking ends when they drop it off at the PB location.

The interesting thing about this is that the tracking response is kind of a flat json object vs nested like `shipment => packages => etc` that we see in other providers. Not really a big deal, just a little weird to be passing the same object from response -> shipment -> package.

Another oddity/annoyance is that the tracking numbers are the same as USPS (or whatever first leg service we would use) so `tracking_regex.test?` will be true for PB and USPS. But it won't really matter on the RS tracking end since we map to the class by provider so we don't really use the "find tracking class by tracking number" functionality. 

Added basic basic test because they don't have test tracking numbers so I had to use the JSON from the test labels.

The tracking url ain't bad either
https://trackpb.shipment.co/track/92023903406069000000000285
