### PR TITLE
FedEx More "Left" Codes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniship (0.5.0)
+    omniship (0.5.1)
       curb
       json
       nokogiri (= 1.16)

--- a/lib/omniship/fedex/track/package.rb
+++ b/lib/omniship/fedex/track/package.rb
@@ -4,10 +4,12 @@ module Omniship
       class Package < Omniship::Base
         # https://developer.fedex.com/api/en-us/guides/api-reference.html#trackingstatuscodes
         DELIVERED = 'DL'.freeze
-        # Picked up
-        # Left FedEx origin facility
-        # Arrived at FedEx location
-        LEFT_CODES = %w[PU DP AR].freeze
+        # PU: Picked up
+        # DP: Left FedEx origin facility
+        # AR: Arrived at FedEx location
+        # OD: Out for Delivery
+        # IT: In Transit
+        LEFT_CODES = %w[PU DP AR OD IT].freeze
 
         def tracking_number
           root.dig('trackingNumberInfo', 'trackingNumber')

--- a/lib/omniship/version.rb
+++ b/lib/omniship/version.rb
@@ -1,3 +1,3 @@
 module Omniship
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end


### PR DESCRIPTION
Created some prod credentials and was spot checking tracking. 

```
[["IT", "In transit", "XX, TX XX US"],
 ["IT", "In transit", "XX, TX XX US"],
 ["IT", "In transit", "XX, TX XX US"],
 ["IT", "In transit", "XX, TX XX US"],
 ["IT", "In transit", "XX, TX XX US"],
 ["IT", "In transit", "NEW BERLIN, WI 53151 US"],
 ["IN", "Label created", ",  53207 US"]]
```

Here are the codes/status for a package. that won't be considered "left" by the current codes. So add a couple more from https://developer.fedex.com/api/en-us/guides/api-reference.html#trackingstatuscodes

In theory the derived codes should be the _general_ status for the specific code but we'll have to see. Easy enough to deal with