### PR TITLE
WOEM 14042 | FedEx Error Handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniship (0.5.1)
+    omniship (0.5.2)
       curb
       json
       nokogiri (= 1.16)

--- a/lib/omniship/version.rb
+++ b/lib/omniship/version.rb
@@ -1,3 +1,3 @@
 module Omniship
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end

--- a/spec/fedex/track_spec.rb
+++ b/spec/fedex/track_spec.rb
@@ -20,4 +20,10 @@ describe "FedEx::Track" do
     expect(activity.status).to_not be_nil
     expect(activity.timestamp).to_not be_nil
   end
+
+  it 'test json parsing raising error' do
+    errors = Omniship::FedEx::Track::Request.send(:find_track_errors, track_fedex_not_found_response.dig('output', 'completeTrackResults'))
+
+    expect(errors).to_not be_empty
+  end
 end

--- a/spec/mock_responses.rb
+++ b/spec/mock_responses.rb
@@ -2073,4 +2073,23 @@ module MockResponses
     }
     JSON
   end
+
+  def track_fedex_not_found_response
+    {
+      "transactionId"=>"5243a255-b1ab-454f-884c-0a2ffd49a7aa",
+      "customerTransactionId"=>"a22ada43-ea34-45c9-9141-bddbde189d35",
+      "output"=>{
+        "completeTrackResults"=>[{
+          "trackingNumber"=>"02399989320920003663",
+          "trackResults"=>[{
+            "trackingNumberInfo"=>{"trackingNumber"=>"02399989320920003663", "trackingNumberUniqueId"=>"", "carrierCode"=>""},
+            "error"=>{
+              "code"=>"TRACKING.TRACKINGNUMBER.NOTFOUND",
+              "message"=>"The tracking number you entered can't be found right now. Please check the number with the shipper or try again later."
+            }
+          }]
+        }]
+      }
+    }
+  end
 end


### PR DESCRIPTION
On "Tracking Not found" responses it's still a 200 :( and any error is nested in pretty deep. A bummer but what can ya do

I'm not doing this in Shipment/Package because I want to keep with the "all errors raised in the Request class. and if it gets past it should be a valid tracking request.

```json
{
  "transactionId": "5243a255-b1ab-454f-884c-0a2ffd49a7aa",
  "customerTransactionId": "a22ada43-ea34-45c9-9141-bddbde189d35",
  "output": {
    "completeTrackResults": [
      {
        "trackingNumber": "02399989320920003663",
        "trackResults": [
          {
            "trackingNumberInfo": {
              "trackingNumber": "02399989320920003663",
              "trackingNumberUniqueId": "",
              "carrierCode": ""
            },
            "error": {
              "code": "TRACKING.TRACKINGNUMBER.NOTFOUND",
              "message": "The tracking number you entered can't be found right now. Please check the number with the shipper or try again later."
            }
          }
        ]
      }
    ]
  }
}
```

This issue only effects tracking where we've created the label but FedEx hasn't picked them up yet.

