### PR TITLE
WOEM 14071 | FedEx | Error Handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniship (0.5.2)
+    omniship (0.5.3)
       curb
       json
       nokogiri (= 1.16)

--- a/lib/omniship/fedex/track/request.rb
+++ b/lib/omniship/fedex/track/request.rb
@@ -55,6 +55,8 @@ module Omniship
           #   }]
           # }]
           def find_track_errors(track_results)
+            return [{ 'code' => '', 'message' => 'completeTrackResults is null' }] if track_results.nil?
+
             track_results.flat_map  do |result|
               next unless result.key?('trackResults')
 

--- a/lib/omniship/version.rb
+++ b/lib/omniship/version.rb
@@ -1,3 +1,3 @@
 module Omniship
-  VERSION = '0.5.2'
+  VERSION = '0.5.3'
 end

--- a/spec/fedex/track_spec.rb
+++ b/spec/fedex/track_spec.rb
@@ -26,4 +26,10 @@ describe "FedEx::Track" do
 
     expect(errors).to_not be_empty
   end
+
+  it 'test json parsing raising error if nil' do
+    errors = Omniship::FedEx::Track::Request.send(:find_track_errors, nil)
+
+    expect(errors).to_not be_empty
+  end
 end


### PR DESCRIPTION
I'm not sure how I feel about this change.

The error that's being raised is 
![image](https://github.com/user-attachments/assets/4cfad170-4987-4901-84ca-5682cd8df051)
![image](https://github.com/user-attachments/assets/0c13c6e3-e73e-4086-a542-af22c7a0c2e4)

That means `completeTrackResults` is nil but then why would it respond with a 200 or why wouldn't `errors` be populated in the original response object. 

It feels like a weird race condition that's only happening _some_ of the time which makes things more annoying. So if that method gets a nil. return an error array so then maybe we can figure out a better solution in the future 