### PR TITLE
Parse Fedex dateAndTimes when estimatedDeliveryTimeWindow is blank

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniship (0.5.3)
+    omniship (0.5.4)
       curb
       json
       nokogiri (= 1.16)
@@ -10,23 +10,29 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    curb (1.0.5)
+    coderay (1.1.3)
+    curb (1.0.6)
     diff-lcs (1.2.5)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
+    domain_name (0.6.20240107)
     http-accept (1.7.0)
-    http-cookie (1.0.5)
+    http-cookie (1.0.7)
       domain_name (~> 0.5)
-    json (2.6.3)
-    mime-types (3.5.1)
+    json (2.7.2)
+    logger (1.6.1)
+    method_source (1.1.0)
+    mime-types (3.6.0)
+      logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2023.0808)
-    mini_portile2 (2.8.4)
+    mime-types-data (3.2024.1001)
+    mini_portile2 (2.8.7)
     netrc (0.11.0)
     nokogiri (1.16.0)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    racc (1.7.1)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    racc (1.8.1)
     rake (11.2.2)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -46,15 +52,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.8.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   omniship!
+  pry
   rake
   rspec
 

--- a/lib/omniship/fedex/track/package.rb
+++ b/lib/omniship/fedex/track/package.rb
@@ -34,7 +34,14 @@ module Omniship
 
           window = root.dig('estimatedDeliveryTimeWindow', 'window', 'begins')
 
-          return if window.nil? || window.empty?
+          if window.nil? || window.empty?
+            dates_and_times = root.dig('dateAndTimes')
+            return unless dates_and_times
+            estimated_delivery = dates_and_times.detect{|x| ['ACTUAL_DELIVERY', 'ESTIMATED_DELIVERY'].include?(x['type']) }
+
+            return unless estimated_delivery
+            window = estimated_delivery['dateTime']
+          end
 
           Omniship::FedEx.parse_timestamp(window)
         end

--- a/lib/omniship/fedex/track/package.rb
+++ b/lib/omniship/fedex/track/package.rb
@@ -36,10 +36,13 @@ module Omniship
 
           if window.nil? || window.empty?
             dates_and_times = root.dig('dateAndTimes')
+
             return unless dates_and_times
+
             estimated_delivery = dates_and_times.detect{|x| ['ACTUAL_DELIVERY', 'ESTIMATED_DELIVERY'].include?(x['type']) }
 
             return unless estimated_delivery
+
             window = estimated_delivery['dateTime']
           end
 

--- a/lib/omniship/version.rb
+++ b/lib/omniship/version.rb
@@ -1,3 +1,3 @@
 module Omniship
-  VERSION = '0.5.3'
+  VERSION = '0.5.4'
 end

--- a/omniship.gemspec
+++ b/omniship.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency('nokogiri', "1.16")
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec')
+  s.add_development_dependency('pry')
 
   # = MANIFEST =
   s.files =  Dir.glob("{lib}/**/*") + %w(LICENSE README.md)

--- a/spec/fedex/track_spec.rb
+++ b/spec/fedex/track_spec.rb
@@ -11,14 +11,27 @@ describe "FedEx::Track" do
 
     package = trk.shipment.packages.first
     expect(package.tracking_number).to_not be_nil
-
-    expect(trk.shipment.scheduled_delivery).to_not be_nil
+    expect(trk.shipment.scheduled_delivery.to_date).to_not be_nil
+    expect(trk.shipment.scheduled_delivery.to_date).to eq Date.parse('2024-08-14')
 
     activity = package.activity.first
 
     expect(activity.code).to_not be_nil
     expect(activity.status).to_not be_nil
     expect(activity.timestamp).to_not be_nil
+  end
+
+  it 'test json parsing estimated delivery without a time window' do
+    resp = JSON.parse(track_fedex_response).dig('output', 'completeTrackResults')
+    resp.first['trackResults'].first['estimatedDeliveryTimeWindow'] = nil
+    trk = Omniship::FedEx::Track::Response.new(resp)
+
+    expect(trk.has_left?).to eq true
+    expect(trk.has_arrived?).to eq true
+
+    package = trk.shipment.packages.first
+    expect(trk.shipment.scheduled_delivery.to_date).to_not be_nil
+    expect(trk.shipment.scheduled_delivery.to_date).to eq Date.parse('2007-09-27')
   end
 
   it 'test json parsing raising error' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ Bundler.setup
 
 require 'omniship'
 require 'mock_responses'
+require 'pry'
+
 
 # these are production numbers from real shipments
 # they are not varying enough to consider this a 100% test but they are a start at least


### PR DESCRIPTION
Related to data shared here: https://github.com/wantable/wantable-2/pull/14023
