### PR TITLE
WOEM 16869 | Amazon | Tracking Url & Prefixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniship (0.6.0)
+    omniship (0.6.1)
       curb
       json
       nokogiri (= 1.16)

--- a/lib/omniship.rb
+++ b/lib/omniship.rb
@@ -131,6 +131,10 @@ module Omniship
     end
   end
 
+  def self.access_token_required?
+    false
+  end
+
   private
 
   def self.provider_from_number(number)

--- a/lib/omniship/amazon.rb
+++ b/lib/omniship/amazon.rb
@@ -5,7 +5,7 @@ module Omniship
     LABEL = 'Amazon'.freeze
     TRACKING_REGEX = [/\ATB[A-Z]\d+\z/]
 
-    TRACKING_URL = 'https://track.amazon.com/tracking'.freeze
+    TRACKING_URL = 'https://track.amazon.com/tracking/'.freeze
 
     class << self
       attr_accessor :test

--- a/lib/omniship/amazon.rb
+++ b/lib/omniship/amazon.rb
@@ -3,9 +3,9 @@ require 'omniship/amazon/track'
 module Omniship
   module Amazon
     LABEL = 'Amazon'.freeze
-    TRACKING_REGEX = []
+    TRACKING_REGEX = [/\ATB[A-Z]\d+\z/]
 
-    TRACKING_URL = 'https://track.amazon.com/'.freeze
+    TRACKING_URL = 'https://track.amazon.com/tracking'.freeze
 
     class << self
       attr_accessor :test

--- a/lib/omniship/version.rb
+++ b/lib/omniship/version.rb
@@ -1,3 +1,3 @@
 module Omniship
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end

--- a/spec/amazon/track_spec.rb
+++ b/spec/amazon/track_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe "Amazon::Track" do
+  it 'matches tracking prefixes' do
+    expect(Omniship::Amazon::tracking_test?('TBA123456789012')).to(eq(true))
+    expect(Omniship::Amazon::tracking_test?('TBM123456789012')).to(eq(true))
+    expect(Omniship::Amazon::tracking_test?('TBC123456789012')).to(eq(true))
+    expect(Omniship::Amazon::tracking_test?('123456789012')).to(eq(false))
+  end
+
   it 'raises error without bearer token' do
     expect { Omniship::Amazon.track('9261290289104185136058', access_token: nil) }.to raise_error(RuntimeError)
   end
@@ -38,10 +45,5 @@ describe "Amazon::Track" do
     expect(activity.status).to_not be_nil
     expect(activity.address.to_s).to eq("Bethpage, NY 11714 US")
     expect(activity.timestamp).to_not be_nil
-  end
-
-  it 'test json parsing not found' do
-    error = Omniship::Amazon::Track::Error.new(track_usps_not_found_response)
-    expect(error.code).to eq('400')
   end
 end


### PR DESCRIPTION
the logic in `TRACKING_REGEX` shouldn't be used since we map stuff pretty well in omnitrackable. But nice to know that there is a fallback.

Also define a method for the Omniship module for `access_token_required?` related to a fix that once update to 0.6.1 can remove.

<!--- issue number --->
[WOEM-16869 (0.1)](https://wantable.atlassian.net/browse/WOEM-16869) - Modify Amazon Outbound Tracking URL:
> Modify the tracking url that amazon outbound uses.

<!--- Deleting this will break code tracker, don't do it. I'm watching you. --->